### PR TITLE
feature/row-count-estimation: implement row count estimation and monthly climatology support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Custom build process that renames index.html to app.html
 - Material-UI theming system with custom theme configuration
 - **Responsive Design**: Application is responsive for tablet and desktop viewports. Mobile viewport support is intentionally not implemented.
-- **Material-UI Class Names**: Never use string matching or logic based on Material-UI generated class names as they get minified in production builds.
+- **Material-UI Styling**: Never use string matching on generated class names (minified in production) or class ternaries for state-based styling. Use inline `style` prop for conditional styling to avoid CSS-in-JS specificity conflicts.
 
 ## Testing
 
@@ -215,6 +215,39 @@ function MyComponent({ data }) {
   ```
 
 - **Documentation**: See `src/features/catalogSearch/api/README.md` for complete architecture overview
+
+### Stale Row Count Indicators (2025-11)
+
+- **Per-Dataset Staleness Detection**: Tracks constraint state per dataset when row counts are calculated, enabling intelligent staleness indicators that only appear when counts may be inaccurate
+- **Dual Staleness Logic**:
+  - **Initial (no snapshot)**: Stale if temporal/depth enabled with valid values OR spatial coverage < 100%
+  - **Post-Recalculation (snapshot exists)**: Stale if current constraints differ from dataset's snapshot
+- **Constraint Snapshot Structure**: Per-dataset snapshots capture `{ spatialBounds, temporalRange, depthRange, temporalEnabled, depthEnabled, includePartialOverlaps, timestamp }` in `datasetConstraintSnapshots` map
+- **Refined Recalculation Filtering**: Only recalculates datasets marked as stale (excludes satellite/model types and datasets with accurate counts)
+- **Stale Indicator UI Pattern**:
+  - Material-UI `WarningIcon` (yellow) displayed next to row count when stale
+  - `StaleIndicatorTooltip` component with reason-based message templates
+  - Embedded "Recalculate" button (hidden after "Recalculate All" is used)
+  - Tooltips support multiple staleness reasons: `spatial_partial`, `temporal_enabled`, `depth_enabled`, `constraints_changed`, `dataset_not_in_results`
+- **Constraint Comparison**: Deep equality check via `areConstraintsEqual()` with Date object handling (compares by `.getTime()`), enabled state logic (only compares ranges when enabled in BOTH), and null value support
+- **Usage Example**:
+
+  ```javascript
+  // In Zustand store - check if dataset is stale
+  const { isStale, reason } = get().isDatasetStale(shortName, currentConstraints, datasetUtilization, datasetType);
+  // Returns { isStale: true, reason: 'spatial_partial' }
+
+  // In component - render stale indicator
+  {
+    isStale && (
+      <StaleIndicatorTooltip reason={reason} dataset={dataset} onRecalculate={() => handleRecalculate(dataset)} isRecalculating={isRecalculating} hasUsedGlobalRecalculation={hasUsedGlobalRecalculation}>
+        <WarningIcon style={{ color: '#fdd835', fontSize: 16 }} />
+      </StaleIndicatorTooltip>
+    );
+  }
+  ```
+
+- **Testing**: Manual test scenarios documented in `specs/012-users-howardwkim-src/quickstart.md` covering initial staleness, recalculation triggers, constraint modifications, edge cases, and regression testing
 
 ### Performance Patterns
 

--- a/public/sqlite-wasm/catalogSearchConfig.js
+++ b/public/sqlite-wasm/catalogSearchConfig.js
@@ -133,18 +133,21 @@ const MESSAGE_TYPES = {
   INIT: 'init',
   SEARCH: 'search',
   GET_REGIONS: 'get-regions',
+  EXECUTE_SQL: 'execute-sql',
   CLEANUP: 'cleanup',
 
   // Outgoing success messages (worker -> main thread)
   INIT_SUCCESS: 'init-success',
   SEARCH_RESULTS: 'search-results',
   REGIONS_RESULTS: 'regions-results',
+  SQL_RESULTS: 'sql-results',
   CLEANUP_SUCCESS: 'cleanup-success',
 
   // Outgoing error messages (worker -> main thread)
   INIT_ERROR: 'init-error',
   SEARCH_ERROR: 'search-error',
   REGIONS_ERROR: 'regions-error',
+  SQL_ERROR: 'sql-error',
   CLEANUP_ERROR: 'cleanup-error',
   ERROR: 'error',
 };

--- a/public/sqlite-wasm/catalogSearchWorker.js
+++ b/public/sqlite-wasm/catalogSearchWorker.js
@@ -409,6 +409,41 @@ function getRegions(searchId) {
 }
 
 /**
+ * Execute raw SQL query with parameter bindings
+ * Used for accessing estimation tables and other custom queries
+ * @param {string} sql - SQL query with ? placeholders
+ * @param {Array|object} bindings - Parameter bindings (array for positional, object for named)
+ * @param {number} searchId - Search ID for response correlation
+ */
+function executeSql(sql, bindings, searchId) {
+  try {
+    if (!db) {
+      throw new Error('Database not initialized');
+    }
+
+    const results = [];
+
+    db.exec({
+      sql,
+      bind: bindings,
+      rowMode: 'object',
+      callback: (row) => {
+        results.push(row);
+      },
+    });
+
+    postMessage({ type: MESSAGE_TYPES.SQL_RESULTS, searchId, results });
+  } catch (error) {
+    console.error('[Worker] SQL execution error:', error);
+    postMessage({
+      type: MESSAGE_TYPES.SQL_ERROR,
+      searchId,
+      error: error.message || 'SQL execution failed',
+    });
+  }
+}
+
+/**
  * Cleanup resources
  */
 function cleanup() {
@@ -428,7 +463,7 @@ function cleanup() {
 
 // Message handler
 self.onmessage = (event) => {
-  const { type, dbBlob, query, searchId } = event.data;
+  const { type, dbBlob, query, searchId, sql, bindings } = event.data;
 
   switch (type) {
     case MESSAGE_TYPES.INIT:
@@ -439,6 +474,9 @@ self.onmessage = (event) => {
       break;
     case MESSAGE_TYPES.GET_REGIONS:
       getRegions(searchId);
+      break;
+    case MESSAGE_TYPES.EXECUTE_SQL:
+      executeSql(sql, bindings, searchId);
       break;
     case MESSAGE_TYPES.CLEANUP:
       cleanup();

--- a/public/sqlite-wasm/sqlQueryTemplates.js
+++ b/public/sqlite-wasm/sqlQueryTemplates.js
@@ -116,6 +116,34 @@ function buildSelectClause(includeRank = false, tableAlias = 'd', ftsAlias = 'ft
         END
       ) AS dataset_utilization,
 
+      -- Temporal utilization (percentage of dataset's temporal extent within user range)
+      (
+        CASE
+          WHEN $userTimeMin IS NULL OR $userTimeMax IS NULL THEN NULL
+          WHEN ${tableAlias}.${columns.timeMax} IS NULL OR ${tableAlias}.${columns.timeMin} IS NULL THEN NULL
+          WHEN json_extract(${tableAlias}.${columns.metadataJson}, '$.isClimatology') = 1 THEN 1.0
+          WHEN ${tableAlias}.${columns.timeMax} < $userTimeMin OR ${tableAlias}.${columns.timeMin} > $userTimeMax THEN 0.0
+          ELSE ROUND(
+            (julianday(MIN(${tableAlias}.${columns.timeMax}, $userTimeMax)) -
+             julianday(MAX(${tableAlias}.${columns.timeMin}, $userTimeMin))) /
+            NULLIF((julianday(${tableAlias}.${columns.timeMax}) - julianday(${tableAlias}.${columns.timeMin})), 0)
+          , 2)
+        END
+      ) AS temporal_utilization,
+
+      -- Depth utilization (percentage of dataset's depth extent within user range)
+      (
+        CASE
+          WHEN $userDepthMin IS NULL OR $userDepthMax IS NULL THEN NULL
+          WHEN ${tableAlias}.${columns.depthMax} IS NULL OR ${tableAlias}.${columns.depthMin} IS NULL THEN NULL
+          WHEN ${tableAlias}.${columns.depthMax} < $userDepthMin OR ${tableAlias}.${columns.depthMin} > $userDepthMax THEN 0.0
+          ELSE ROUND(
+            (MIN(${tableAlias}.${columns.depthMax}, $userDepthMax) - MAX(${tableAlias}.${columns.depthMin}, $userDepthMin)) /
+            NULLIF((${tableAlias}.${columns.depthMax} - ${tableAlias}.${columns.depthMin}), 0)
+          , 2)
+        END
+      ) AS depth_utilization,
+
       -- Spatial coverage ratio (0-1 range, rounded to 2 decimal places)
       -- Shows what percentage of the ROI is covered by the dataset
       -- NOTE: This metric is calculated for informational purposes only.

--- a/src/features/catalogSearch/api/catalogDbApi.js
+++ b/src/features/catalogSearch/api/catalogDbApi.js
@@ -318,6 +318,55 @@ async function downloadDatabase() {
 }
 
 /**
+ * Check if cached database is current (schema version and data checksum)
+ * Makes a lightweight HEAD request to check server metadata
+ * @param {object} cachedVersion - Version metadata from cached database
+ * @returns {Promise<boolean>} True if cache matches server (both schema and data)
+ */
+async function hasCurrentVersion(cachedVersion) {
+  try {
+    const endpoint = `${apiUrl}/api/catalog/full-catalog-db`;
+    const response = await fetch(endpoint, {
+      method: 'HEAD',
+      ...fetchOptions,
+    });
+
+    if (!response.ok) {
+      console.warn('[Cache] Failed to check server version, assuming cache is valid');
+      return true; // Fail open - use cache if we can't check
+    }
+
+    const serverSchemaVersion = response.headers.get('X-Catalog-Version');
+    const serverChecksum = response.headers.get('X-Catalog-Checksum');
+    const cachedSchemaVersion = cachedVersion.schemaVersion;
+    const cachedChecksum = cachedVersion.checksum;
+
+    // Check schema version
+    if (serverSchemaVersion && serverSchemaVersion !== cachedSchemaVersion) {
+      console.log('[Cache] Schema version changed - invalidating cache', {
+        cached: cachedSchemaVersion,
+        server: serverSchemaVersion,
+      });
+      return false;
+    }
+
+    // Check data checksum
+    if (serverChecksum && serverChecksum !== cachedChecksum) {
+      console.log('[Cache] Data checksum changed - invalidating cache (datasets added/updated)', {
+        cached: cachedChecksum,
+        server: serverChecksum,
+      });
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.warn('[Cache] Error checking server version:', error);
+    return true; // Fail open - use cache if we can't check
+  }
+}
+
+/**
  * Load database (from cache or download)
  * @returns {Promise<ArrayBuffer>}
  */
@@ -325,10 +374,18 @@ export async function loadDatabase() {
   // Try to load from cache first
   const cached = await getCachedDatabase();
   if (cached) {
-    return cached.blob;
+    // Check if schema version and data checksum are current
+    const isCurrent = await hasCurrentVersion(cached.version);
+    if (isCurrent) {
+      return cached.blob;
+    }
+
+    // Schema or data changed, clear cache and download fresh
+    console.log('[Cache] Clearing outdated cache');
+    await clearCache();
   }
 
-  // Cache miss or expired, download fresh copy
+  // Cache miss, expired, or data changed - download fresh copy
   const { blob, version } = await downloadDatabase();
 
   // Store in cache for next time

--- a/src/features/catalogSearch/api/index.js
+++ b/src/features/catalogSearch/api/index.js
@@ -60,6 +60,9 @@ import {
   resetSearchDatabaseApi,
 } from './searchDatabaseApi';
 
+// Re-export low-level API access (for advanced use cases like estimation)
+export { getSearchDatabaseApi };
+
 // Re-export query construction and constants
 export {
   createSearchQuery,

--- a/src/features/catalogSearch/api/searchDatabaseApi.js
+++ b/src/features/catalogSearch/api/searchDatabaseApi.js
@@ -117,6 +117,27 @@ class SearchDatabaseApi {
   }
 
   /**
+   * Execute raw SQL query with parameter bindings
+   * @param {string} sql - SQL query with ? placeholders
+   * @param {Array|object} bindings - Parameter bindings (array for positional ?, object for named params)
+   * @returns {Promise<Array>} Array of result rows
+   */
+  async executeSql(sql, bindings = []) {
+    if (!this.isInitialized) {
+      throw new Error(
+        'Search service not initialized. Call initialize() first.',
+      );
+    }
+
+    const results = await this.sendWorkerMessage('execute-sql', {
+      sql,
+      bindings,
+    });
+
+    return results;
+  }
+
+  /**
    * Cleanup resources
    */
   cleanup() {
@@ -227,6 +248,22 @@ class SearchDatabaseApi {
         break;
 
       case 'regions-error':
+        if (this.pendingSearches.has(searchId)) {
+          const pending = this.pendingSearches.get(searchId);
+          this.pendingSearches.delete(searchId);
+          pending.reject(new Error(error));
+        }
+        break;
+
+      case 'sql-results':
+        if (this.pendingSearches.has(searchId)) {
+          const pending = this.pendingSearches.get(searchId);
+          this.pendingSearches.delete(searchId);
+          pending.resolve(results);
+        }
+        break;
+
+      case 'sql-error':
         if (this.pendingSearches.has(searchId)) {
           const pending = this.pendingSearches.get(searchId);
           this.pendingSearches.delete(searchId);

--- a/src/features/catalogSearch/api/transformers/searchResultTransformer.js
+++ b/src/features/catalogSearch/api/transformers/searchResultTransformer.js
@@ -148,6 +148,10 @@ export const transformSearchResult = (row) => {
     temporal_coverage: row.temporal_coverage,
     depth_coverage: row.depth_coverage,
 
+    // Utilization metrics (for future use)
+    temporal_utilization: row.temporal_utilization,
+    depth_utilization: row.depth_utilization,
+
     // Additional metadata
     metadata,
 

--- a/src/features/collections/addDatasets/AddDatasetsModal.js
+++ b/src/features/collections/addDatasets/AddDatasetsModal.js
@@ -195,6 +195,7 @@ const AddDatasetsModal = ({
           name: collection.name,
           datasetCount: collection.datasetCount || 0,
           isPublic: collection.isPublic || false,
+          isOwner: collection.isOwner || false,
           // Include additional metadata for CollectionSummaryCard
           ownerName: collection.ownerName,
           ownerAffiliation: collection.ownerAffiliation,

--- a/src/features/collections/addDatasets/CatalogSearchTab/CatalogSearchSection.js
+++ b/src/features/collections/addDatasets/CatalogSearchTab/CatalogSearchSection.js
@@ -31,7 +31,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import useCatalogSearchStore from '../../../catalogSearch/state/catalogSearchStore';
 import DatasetsTableSection from '../components/DatasetsTableSection';
 import UniversalButton from '../../../../shared/components/UniversalButton';
-import SingleStatistic from '../../components/SingleStatistic';
 import DateInput from '../../../../shared/components/DateInput';
 import zIndex from '../../../../enums/zIndex';
 
@@ -60,9 +59,6 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     gap: theme.spacing(2),
     flexShrink: 0,
-  },
-  statisticsWrapper: {
-    marginBottom: theme.spacing(2),
   },
   loadingContainer: {
     display: 'flex',
@@ -104,14 +100,6 @@ const CatalogSearchSection = ({
 
   // Define available data types
   const dataTypes = ['Model', 'Satellite', 'In-Situ'];
-
-  // Calculate "already in collection" count
-  const alreadyInCollectionCount = React.useMemo(() => {
-    if (results.length === 0) return 0;
-    return results.filter((dataset) =>
-      currentCollectionDatasetIds.has(dataset.shortName),
-    ).length;
-  }, [results, currentCollectionDatasetIds]);
 
   // Sync local input text with store when store is reset
   useEffect(() => {
@@ -344,20 +332,6 @@ const CatalogSearchSection = ({
           </Box>
         )}
       </Box>
-
-      {/* Statistics - Show when there are results */}
-      {results.length > 0 && alreadyInCollectionCount > 0 && (
-        <Box className={classes.statisticsWrapper}>
-          <SingleStatistic
-            value={alreadyInCollectionCount}
-            label="Already in Collection"
-            borderColor="rgba(128, 128, 128, 0.6)"
-            compact
-            maxWidth="280px"
-            noEllipsis
-          />
-        </Box>
-      )}
 
       {/* Results Table - Always shown, matching FromCollectionsTab pattern */}
       <DatasetsTableSection

--- a/src/features/collections/addDatasets/SpatialTemporalTab/components/DepthConstraintsInput.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/components/DepthConstraintsInput.js
@@ -95,7 +95,7 @@ const DepthConstraintsInput = () => {
     setDepthMax(depthRange.depthMax !== null ? depthRange.depthMax : '');
   }, [depthRange.depthMin, depthRange.depthMax]);
 
-  // Validate and update store when inputs change
+  // Validate inputs for immediate feedback (but don't update store)
   useEffect(() => {
     if (!depthEnabled) {
       setValidationErrors([]);
@@ -109,18 +109,10 @@ const DepthConstraintsInput = () => {
       depthMax: depthMax,
     };
 
-    // Validate
+    // Validate (show errors immediately)
     const validation = validateDepthRange(constraints);
     setValidationErrors(validation.errors);
-
-    // Update store if valid
-    if (validation.valid) {
-      setDepthConstraints(depthEnabled, {
-        depthMin: Number(depthMin),
-        depthMax: Number(depthMax),
-      });
-    }
-  }, [depthEnabled, depthMin, depthMax, setDepthConstraints]);
+  }, [depthEnabled, depthMin, depthMax]);
 
   /**
    * Handle checkbox toggle for enabling/disabling depth constraints
@@ -150,6 +142,32 @@ const DepthConstraintsInput = () => {
    */
   const handleDepthMaxChange = (event) => {
     setDepthMax(event.target.value);
+  };
+
+  /**
+   * Handle blur events - update store only when user finishes editing
+   * This prevents premature constraint snapshot comparisons during typing
+   */
+  const handleBlur = () => {
+    if (!depthEnabled) {
+      return;
+    }
+
+    // Prepare constraints for validation
+    const constraints = {
+      enabled: depthEnabled,
+      depthMin: depthMin,
+      depthMax: depthMax,
+    };
+
+    // Only update store if valid
+    const validation = validateDepthRange(constraints);
+    if (validation.valid) {
+      setDepthConstraints(depthEnabled, {
+        depthMin: Number(depthMin),
+        depthMax: Number(depthMax),
+      });
+    }
   };
 
   return (
@@ -183,6 +201,7 @@ const DepthConstraintsInput = () => {
               type="number"
               value={depthMin}
               onChange={handleDepthMinChange}
+              onBlur={handleBlur}
               variant="outlined"
               size="small"
               InputLabelProps={{ shrink: true }}
@@ -197,6 +216,7 @@ const DepthConstraintsInput = () => {
               type="number"
               value={depthMax}
               onChange={handleDepthMaxChange}
+              onBlur={handleBlur}
               variant="outlined"
               size="small"
               InputLabelProps={{ shrink: true }}

--- a/src/features/collections/addDatasets/SpatialTemporalTab/components/RowCountCell.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/components/RowCountCell.js
@@ -1,0 +1,244 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, CircularProgress } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import WarningIcon from '@material-ui/icons/Warning';
+import InfoIcon from '@material-ui/icons/Info';
+import StaleIndicatorTooltip from './StaleIndicatorTooltip';
+import ClusterOnlyTooltip from './SkipReasonTooltip';
+import useRowCountCalculationStore from '../store/rowCountCalculationStore';
+import useSpatialTemporalSearchStore from '../store/spatialTemporalSearchStore';
+
+const useStyles = makeStyles((theme) => ({
+  rowCountLoading: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  failedRowCount: {
+    color: '#c62828', // Prominent red (matching private chip pattern)
+    fontSize: '0.75rem',
+    fontStyle: 'italic',
+  },
+  clusterOnlyRowCount: {
+    color: '#90a4ae', // Gray/blue for cluster-only
+    fontSize: '0.75rem',
+    fontStyle: 'italic',
+  },
+  recalculatedRowCount: {
+    color: '#8bc34a', // Vibrant green
+    fontSize: '0.75rem',
+    fontStyle: 'italic',
+  },
+  estimatedRowCount: {
+    color: '#9c27b0', // Purple (Material-UI primary purple)
+    fontSize: '0.75rem',
+    fontStyle: 'italic',
+  },
+}));
+
+/**
+ * RowCountCell Component
+ *
+ * Displays row count for a dataset with support for:
+ * - Loading state (spinner)
+ * - Estimated row count (white number + purple "(estimate)" label)
+ * - Recalculated row count (white number + green "(recalculated)" label)
+ * - Failed calculation (original count + red "(failed)")
+ * - Cluster-only dataset (original count + gray info icon + "(cluster only)" label with tooltip)
+ * - Default state (original count from dataset stats)
+ *
+ * @param {Object} props
+ * @param {Object} props.dataset - Dataset object with shortName and rows
+ * @param {Object} props.calculatedRowCounts - Map of shortName → calculated count
+ * @param {Array} props.failedRowCounts - Array of shortNames that failed calculation
+ * @param {Array} props.skippedDatasets - Array of shortNames for cluster-only datasets that were skipped
+ * @param {Set} props.rowCountLoadingDatasets - Set of shortNames currently being calculated
+ * @returns {JSX.Element}
+ */
+const RowCountCell = ({
+  dataset,
+  calculatedRowCounts,
+  failedRowCounts,
+  skippedDatasets,
+  rowCountLoadingDatasets,
+}) => {
+  const classes = useStyles();
+  const shortName = dataset.shortName;
+
+  // Access stores for staleness detection and estimation tracking
+  const isDatasetStale = useRowCountCalculationStore(
+    (state) => state.isDatasetStale,
+  );
+  const isDatasetSkipped = useRowCountCalculationStore(
+    (state) => state.isDatasetSkipped,
+  );
+  const calculateRowCountsForDatasets = useRowCountCalculationStore(
+    (state) => state.calculateRowCountsForDatasets,
+  );
+  const buildConstraintsFromStore = useRowCountCalculationStore(
+    (state) => state.buildConstraintsFromStore,
+  );
+  const hasUsedGlobalRecalculation = useRowCountCalculationStore(
+    (state) => state.hasUsedGlobalRecalculation,
+  );
+  const estimatedRowCounts = useRowCountCalculationStore(
+    (state) => state.estimatedRowCounts,
+  );
+  const {
+    spatialBounds,
+    temporalEnabled,
+    temporalRange,
+    depthEnabled,
+    depthRange,
+    includePartialOverlaps,
+  } = useSpatialTemporalSearchStore();
+
+  // Build current constraints object
+  const currentConstraints = {
+    spatialBounds,
+    temporalRange,
+    depthRange,
+    temporalEnabled,
+    depthEnabled,
+    includePartialOverlaps,
+  };
+
+  // Check if dataset is stale
+  const { isStale, reason } = isDatasetStale(
+    shortName,
+    currentConstraints,
+    dataset.datasetUtilization || 1.0,
+    dataset.type,
+  );
+
+  // Callback to recalculate row count for this specific dataset
+  const handleRecalculate = () => {
+    // Recalculate only this dataset - per-dataset snapshot will be stored automatically
+    // Does not consume the global recalculation opportunity (that's only for "Recalculate All")
+    const constraints = buildConstraintsFromStore();
+    calculateRowCountsForDatasets([dataset], constraints);
+  };
+
+  // Check if this dataset is currently being calculated
+  if (rowCountLoadingDatasets.has(shortName)) {
+    return (
+      <Box className={classes.rowCountLoading}>
+        <CircularProgress size={16} color="primary" />
+      </Box>
+    );
+  }
+
+  // Check if this dataset has a calculated row count
+  if (calculatedRowCounts[shortName] !== undefined) {
+    return (
+      <span>
+        {calculatedRowCounts[shortName].toLocaleString()}
+        {isStale ? (
+          // Show stale warning icon (most recent state)
+          <StaleIndicatorTooltip
+            reason={reason}
+            dataset={dataset}
+            onRecalculate={handleRecalculate}
+            isRecalculating={rowCountLoadingDatasets.has(shortName)}
+            hasUsedGlobalRecalculation={hasUsedGlobalRecalculation}
+          >
+            <WarningIcon
+              style={{
+                color: '#fdd835',
+                fontSize: 16,
+                verticalAlign: 'middle',
+                marginLeft: 4,
+              }}
+            />
+          </StaleIndicatorTooltip>
+        ) : (
+          // Show estimate or recalculated label (calculation still valid)
+          <>
+            <br />
+            {estimatedRowCounts.has(shortName) ? (
+              <span className={classes.estimatedRowCount}>(estimate)</span>
+            ) : (
+              <span className={classes.recalculatedRowCount}>(recalculated)</span>
+            )}
+          </>
+        )}
+      </span>
+    );
+  }
+
+  // Check if this dataset failed calculation
+  if (failedRowCounts.includes(shortName)) {
+    return (
+      <span>
+        {typeof dataset.rows === 'number'
+          ? dataset.rows.toLocaleString()
+          : 'N/A'}
+        <br />
+        <span className={classes.failedRowCount}>(failed)</span>
+      </span>
+    );
+  }
+
+  // Check if this dataset was skipped (cluster-only)
+  if (isDatasetSkipped(shortName)) {
+    return (
+      <span>
+        {typeof dataset.rows === 'number'
+          ? dataset.rows.toLocaleString()
+          : 'N/A'}
+        <ClusterOnlyTooltip dataset={dataset}>
+          <InfoIcon
+            style={{
+              color: '#90a4ae',
+              fontSize: 16,
+              verticalAlign: 'middle',
+              marginLeft: 4,
+            }}
+          />
+        </ClusterOnlyTooltip>
+        <br />
+        <span className={classes.clusterOnlyRowCount}>(cluster only)</span>
+      </span>
+    );
+  }
+
+  // Default: show original row count from stats
+  return (
+    <span>
+      {typeof dataset.rows === 'number' ? dataset.rows.toLocaleString() : 'N/A'}
+      {isStale && (
+        <StaleIndicatorTooltip
+          reason={reason}
+          dataset={dataset}
+          onRecalculate={handleRecalculate}
+          isRecalculating={rowCountLoadingDatasets.has(shortName)}
+          hasUsedGlobalRecalculation={hasUsedGlobalRecalculation}
+        >
+          <WarningIcon
+            style={{
+              color: '#fdd835',
+              fontSize: 16,
+              verticalAlign: 'middle',
+              marginLeft: 4,
+            }}
+          />
+        </StaleIndicatorTooltip>
+      )}
+    </span>
+  );
+};
+
+RowCountCell.propTypes = {
+  dataset: PropTypes.shape({
+    shortName: PropTypes.string.isRequired,
+    rows: PropTypes.number,
+    datasetUtilization: PropTypes.number, // Spatial coverage metric (0.0 to 1.0)
+  }).isRequired,
+  calculatedRowCounts: PropTypes.object.isRequired,
+  failedRowCounts: PropTypes.arrayOf(PropTypes.string).isRequired,
+  skippedDatasets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  rowCountLoadingDatasets: PropTypes.instanceOf(Set).isRequired,
+};
+
+export default RowCountCell;

--- a/src/features/collections/addDatasets/SpatialTemporalTab/components/SkipReasonTooltip.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/components/SkipReasonTooltip.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip, Box } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import zIndex from '../../../../../enums/zIndex';
+import logInit from '../../../../../Services/log-service';
+
+const log = logInit('SpatialTemporalTab/SkipReasonTooltip');
+
+const useStyles = makeStyles(() => ({
+  tooltip: {
+    maxWidth: 300,
+    backgroundColor: 'rgba(30, 67, 113, 0.95)',
+    fontSize: 12,
+    padding: 12,
+    borderRadius: 4,
+    zIndex: zIndex.MODAL_LAYER_2_POPPER, // Ensure tooltip appears above AddDatasetsModal (SECONDARY_MODAL)
+  },
+  tooltipContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+  },
+  body: {
+    fontSize: 12,
+    lineHeight: 1.5,
+  },
+}));
+
+/**
+ * ClusterOnlyTooltip Component
+ *
+ * Displays a tooltip explaining that a dataset is currently unavailable for constrained queries.
+ *
+ * @param {Object} props
+ * @param {Object} props.dataset - Dataset object with shortName
+ * @param {React.ReactNode} props.children - The indicator element (text/icon)
+ * @returns {JSX.Element}
+ */
+const ClusterOnlyTooltip = ({ dataset, children }) => {
+  const classes = useStyles();
+
+  const tooltipContent = (
+    <Box className={classes.tooltipContent}>
+      <div className={classes.body}>
+        This dataset is currently unavailable for download with spatial, temporal, or depth constraints due to its large size.
+      </div>
+    </Box>
+  );
+
+  return (
+    <Tooltip
+      title={tooltipContent}
+      classes={{ tooltip: classes.tooltip }}
+      placement="top"
+      interactive
+      aria-describedby={`cluster-only-tooltip-${dataset.shortName}`}
+      PopperProps={{
+        style: { zIndex: zIndex.MODAL_LAYER_2_POPPER },
+      }}
+    >
+      <span aria-label="Dataset unavailable for constrained queries">{children}</span>
+    </Tooltip>
+  );
+};
+
+ClusterOnlyTooltip.propTypes = {
+  dataset: PropTypes.shape({
+    shortName: PropTypes.string.isRequired,
+  }).isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default ClusterOnlyTooltip;

--- a/src/features/collections/addDatasets/SpatialTemporalTab/components/SpatialBoundsInput.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/components/SpatialBoundsInput.js
@@ -92,14 +92,20 @@ const SpatialBoundsInput = () => {
   const { spatialBounds, selectedPreset, setSpatialBounds, applyPreset } =
     useSpatialTemporalSearchStore();
 
-  // Local state for validation errors
+  // Local state for coordinate inputs and validation
+  const [localBounds, setLocalBounds] = useState(spatialBounds);
   const [validationErrors, setValidationErrors] = useState([]);
 
-  // Validate on bounds change
+  // Sync local state with store when store changes
   useEffect(() => {
-    const result = validateSpatialBounds(spatialBounds);
-    setValidationErrors(result.errors);
+    setLocalBounds(spatialBounds);
   }, [spatialBounds]);
+
+  // Validate local bounds for immediate feedback
+  useEffect(() => {
+    const result = validateSpatialBounds(localBounds);
+    setValidationErrors(result.errors);
+  }, [localBounds]);
 
   /**
    * Handle preset selection from dropdown
@@ -122,20 +128,34 @@ const SpatialBoundsInput = () => {
   };
 
   /**
-   * Handle manual coordinate input
+   * Handle manual coordinate input - update local state only
    * @param {string} field - Field name (latMin, latMax, lonMin, lonMax)
    * @param {string} value - Input value
    */
   const handleCoordChange = (field, value) => {
     // Allow empty string or numeric values
     if (value === '' || value === '-') {
-      setSpatialBounds({ [field]: value });
+      setLocalBounds((prev) => ({ ...prev, [field]: value }));
       return;
     }
 
     const numValue = Number(value);
     if (!isNaN(numValue)) {
-      setSpatialBounds({ [field]: numValue });
+      setLocalBounds((prev) => ({ ...prev, [field]: numValue }));
+    }
+  };
+
+  /**
+   * Handle blur events - update store only when user finishes editing
+   * This prevents premature constraint snapshot comparisons during typing
+   */
+  const handleBlur = () => {
+    // Validate before updating store
+    const result = validateSpatialBounds(localBounds);
+
+    // Only update store if valid
+    if (result.valid) {
+      setSpatialBounds(localBounds);
     }
   };
 
@@ -179,8 +199,9 @@ const SpatialBoundsInput = () => {
             type="number"
             label="Start Latitude (°)"
             variant="outlined"
-            value={spatialBounds.latMax ?? ''}
+            value={localBounds.latMax ?? ''}
             onChange={(e) => handleCoordChange('latMax', e.target.value)}
+            onBlur={handleBlur}
             className={classes.coordField}
             InputLabelProps={{ shrink: true }}
             inputProps={{
@@ -194,8 +215,9 @@ const SpatialBoundsInput = () => {
             type="number"
             label="End Latitude (°)"
             variant="outlined"
-            value={spatialBounds.latMin ?? ''}
+            value={localBounds.latMin ?? ''}
             onChange={(e) => handleCoordChange('latMin', e.target.value)}
+            onBlur={handleBlur}
             className={classes.coordField}
             InputLabelProps={{ shrink: true }}
             inputProps={{
@@ -212,8 +234,9 @@ const SpatialBoundsInput = () => {
             type="number"
             label="Start Longitude (°)"
             variant="outlined"
-            value={spatialBounds.lonMax ?? ''}
+            value={localBounds.lonMax ?? ''}
             onChange={(e) => handleCoordChange('lonMax', e.target.value)}
+            onBlur={handleBlur}
             className={classes.coordField}
             InputLabelProps={{ shrink: true }}
             inputProps={{
@@ -227,8 +250,9 @@ const SpatialBoundsInput = () => {
             type="number"
             label="End Longitude (°)"
             variant="outlined"
-            value={spatialBounds.lonMin ?? ''}
+            value={localBounds.lonMin ?? ''}
             onChange={(e) => handleCoordChange('lonMin', e.target.value)}
+            onBlur={handleBlur}
             className={classes.coordField}
             InputLabelProps={{ shrink: true }}
             inputProps={{

--- a/src/features/collections/addDatasets/SpatialTemporalTab/components/SpatialTemporalResultsTable.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/components/SpatialTemporalResultsTable.js
@@ -2,6 +2,7 @@ import React, { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   Box,
+  Button,
   Table,
   TableBody,
   TableCell,
@@ -22,8 +23,11 @@ import {
 import SelectAllDropdown from '../../../../multiDatasetDownload/components/SelectAllDropdown';
 import { SortableHeader } from '../../../../../shared/sorting';
 import useSpatialTemporalSearchStore from '../store/spatialTemporalSearchStore';
+import useRowCountCalculationStore from '../store/rowCountCalculationStore';
 import { useAddDatasetsStore } from '../../state/addDatasetsStore';
 import DataTypeFilterDropdown from './DataTypeFilterDropdown';
+import RowCountCell from './RowCountCell';
+import { createColumnDefinitions } from '../utils/columnDefinitions';
 
 const useStyles = makeStyles((theme) => ({
   tableContainer: {
@@ -54,16 +58,17 @@ const useStyles = makeStyles((theme) => ({
   },
   table: {
     width: '100%',
-  },
-  tableRow: {
-    '&:hover': {
-      backgroundColor: 'rgba(255, 255, 255, 0.05)',
-    },
+    // Apply first-child/last-child padding to ALL rows (header and body)
     '& .MuiTableCell-root:first-child': {
       paddingLeft: '16px',
     },
     '& .MuiTableCell-root:last-child': {
       paddingRight: '16px',
+    },
+  },
+  tableRow: {
+    '&:hover': {
+      backgroundColor: 'rgba(255, 255, 255, 0.05)',
     },
   },
   alreadyPresentRow: {
@@ -90,6 +95,7 @@ const useStyles = makeStyles((theme) => ({
   statusCell: {
     width: '60px',
     textAlign: 'center',
+    textDecoration: 'none !important', // Prevent line-through on status in marked-for-removal rows
   },
   datasetNameCell: {
     minWidth: '200px',
@@ -119,8 +125,28 @@ const useStyles = makeStyles((theme) => ({
     verticalAlign: 'top',
   },
   rowsCell: {
-    width: '100px',
+    width: '120px',
     textAlign: 'right',
+  },
+  rowsHeaderCell: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    gap: theme.spacing(0.5),
+  },
+  recalculateButton: {
+    fontSize: '0.62rem',
+    height: 'auto',
+    minHeight: 32,
+    fontWeight: 700, // Bold text
+    borderRadius: '6px',
+    minWidth: 56,
+    maxWidth: 80, // Forces "Recalculate All" to wrap into two lines at word boundary
+    padding: '4px 8px',
+    textTransform: 'none',
+    whiteSpace: 'normal', // Allows text wrapping
+    lineHeight: 1.2,
+    overflowWrap: 'break-word', // Only breaks at word boundaries, not mid-word
   },
   emptyState: {
     padding: theme.spacing(4),
@@ -185,7 +211,7 @@ const SpatialTemporalResultsTable = ({
   const classes = useStyles({ maxHeight });
   const { getStatusIcon } = useRowStateStyles();
 
-  // Get data type filter, sort mode, and sort direction from store
+  // Get data type filter, sort mode, and sort direction from search store
   const selectedDataTypes = useSpatialTemporalSearchStore(
     (state) => state.selectedDataTypes,
   );
@@ -200,9 +226,58 @@ const SpatialTemporalResultsTable = ({
     (state) => state.setSortMode,
   );
 
+  // Get search constraints from search store (needed for row count calculation)
+  const spatialBounds = useSpatialTemporalSearchStore(
+    (state) => state.spatialBounds,
+  );
+  const temporalRange = useSpatialTemporalSearchStore(
+    (state) => state.temporalRange,
+  );
+  const depthRange = useSpatialTemporalSearchStore((state) => state.depthRange);
+  const includePartialOverlaps = useSpatialTemporalSearchStore(
+    (state) => state.includePartialOverlaps,
+  );
+
+  // Get row count calculation state and action from row count store
+  const calculatedRowCounts = useRowCountCalculationStore(
+    (state) => state.calculatedRowCounts,
+  );
+  const skippedDatasets = useRowCountCalculationStore(
+    (state) => state.skippedDatasets,
+  );
+  const failedRowCounts = useRowCountCalculationStore(
+    (state) => state.failedRowCounts,
+  );
+  const rowCountLoadingDatasets = useRowCountCalculationStore(
+    (state) => state.rowCountLoadingDatasets,
+  );
+  const rowCountsLoading = useRowCountCalculationStore(
+    (state) => state.rowCountsLoading,
+  );
+  const calculateRowCountsForStale = useRowCountCalculationStore(
+    (state) => state.calculateRowCountsForStale,
+  );
+  const buildConstraintsFromStore = useRowCountCalculationStore(
+    (state) => state.buildConstraintsFromStore,
+  );
+  const isDatasetStale = useRowCountCalculationStore(
+    (state) => state.isDatasetStale,
+  );
+  const hasUsedGlobalRecalculation = useRowCountCalculationStore(
+    (state) => state.hasUsedGlobalRecalculation,
+  );
+
   // Handle null results (before first search)
   // SQL filtering now handles all type filtering (1, 2, or 3 types) via IN clause
   const safeResults = results || [];
+
+  // Handle row count calculation button click (header "Recalculate All" button)
+  const handleCalculateRowCounts = useCallback(() => {
+    if (results && results.length > 0) {
+      const constraints = buildConstraintsFromStore();
+      calculateRowCountsForStale(results, constraints);
+    }
+  }, [results, calculateRowCountsForStale, buildConstraintsFromStore]);
 
   // Handle header click to change sort mode
   const handleHeaderClick = useCallback(
@@ -233,6 +308,141 @@ const SpatialTemporalResultsTable = ({
 
   // Use results directly from store (pre-sorted by SQL)
   const sortedResults = safeResults;
+
+  // Define column configuration (single source of truth for headers and body cells)
+  const columnConfig = useMemo(
+    () =>
+      createColumnDefinitions({
+        classes,
+        getStatusIcon,
+        currentCollectionDatasetIds,
+        sortMode,
+        sortDirection,
+        onSortChange: handleHeaderClick,
+        selectedDataTypes,
+        setSelectedDataTypes,
+        resultsCount: safeResults.length,
+      }),
+    [
+      classes,
+      getStatusIcon,
+      currentCollectionDatasetIds,
+      sortMode,
+      sortDirection,
+      handleHeaderClick,
+      selectedDataTypes,
+      setSelectedDataTypes,
+      safeResults.length,
+    ],
+  );
+
+  // Build active columns array based on enabled constraints
+  const activeColumns = useMemo(() => {
+    const columns = [
+      'status',
+      'name',
+      'type',
+      'datasetUtilization',
+      'spatialCoverage',
+    ];
+
+    if (temporalEnabled) {
+      columns.push('temporalCoverage');
+    }
+
+    if (depthEnabled) {
+      columns.push('depthCoverage');
+    }
+
+    // Utilization columns are hidden by default (defined in columnConfig but not shown)
+    // To enable: uncomment the lines below
+    // if (temporalEnabled) {
+    //   columns.push('temporalUtilization');
+    // }
+    //
+    // if (depthEnabled) {
+    //   columns.push('depthUtilization');
+    // }
+
+    if (temporalEnabled) {
+      columns.push('dateOverlap');
+    }
+
+    columns.push('spatialOverlap');
+
+    if (depthEnabled) {
+      columns.push('depthOverlap');
+    }
+
+    return columns;
+  }, [temporalEnabled, depthEnabled]);
+
+  // Check if all datasets have 100% coverage in all enabled dimensions
+  // NOTE: Without temporal_utilization/depth_utilization metrics, we cannot detect
+  // when datasets extend beyond search bounds. Conservative approach: only hide
+  // recalculate button for pure spatial searches with full spatial containment.
+  // When temporal/depth enabled, always show button to avoid false negatives
+  // (hiding button when recalculation would yield different row counts).
+  const allDatasetsFullCoverage = useMemo(() => {
+    if (safeResults.length === 0) return false;
+
+    return safeResults.every((dataset) => {
+      const spatialFull = dataset.datasetUtilization === 1.0;
+      const temporalFull = !temporalEnabled; // Only "full" if not being used
+      const depthFull = !depthEnabled; // Only "full" if not being used
+
+      return spatialFull && temporalFull && depthFull;
+    });
+  }, [safeResults, temporalEnabled, depthEnabled]);
+
+  // Check if all datasets have calculated/skipped/failed row counts
+  const allCountsCalculated = useMemo(() => {
+    if (safeResults.length === 0) return false;
+
+    return safeResults.every((dataset) => {
+      const shortName = dataset.shortName;
+      return (
+        calculatedRowCounts[shortName] !== undefined ||
+        skippedDatasets.includes(shortName) ||
+        failedRowCounts.includes(shortName)
+      );
+    });
+  }, [safeResults, calculatedRowCounts, skippedDatasets, failedRowCounts]);
+
+  // Check if any datasets have stale row counts
+  const hasStaleDatasets = useMemo(() => {
+    if (safeResults.length === 0) return false;
+
+    // Build current constraints object
+    const currentConstraints = {
+      spatialBounds,
+      temporalRange,
+      depthRange,
+      temporalEnabled,
+      depthEnabled,
+      includePartialOverlaps,
+    };
+
+    // Check if any dataset is stale
+    return safeResults.some((dataset) => {
+      const { isStale } = isDatasetStale(
+        dataset.shortName,
+        currentConstraints,
+        dataset.datasetUtilization,
+        dataset.type,
+      );
+      return isStale;
+    });
+  }, [
+    safeResults,
+    spatialBounds,
+    temporalRange,
+    depthRange,
+    temporalEnabled,
+    depthEnabled,
+    includePartialOverlaps,
+    isDatasetStale,
+  ]);
 
   // Determine row class based on dataset state
   const getRowClass = (dataset) => {
@@ -277,17 +487,7 @@ const SpatialTemporalResultsTable = ({
   };
 
   // Calculate total column count for empty state colspan
-  const totalColumnCount =
-    6 + // Base columns: checkbox, status, name, type, dataset utilization (TEMPORARY), rows
-    1 + // Spatial coverage (always shown)
-    (temporalEnabled ? 1 : 0) + // Temporal coverage
-    (depthEnabled ? 1 : 0) + // Depth coverage
-    2 + // Diagnostic: Spatial ratio + Spatial %
-    (temporalEnabled ? 2 : 0) + // Diagnostic: Temporal ratio + Temporal %
-    (depthEnabled ? 2 : 0) + // Diagnostic: Depth ratio + Depth %
-    1 + // Spatial overlap (always shown)
-    (temporalEnabled ? 1 : 0) + // Date overlap
-    (depthEnabled ? 1 : 0); // Depth overlap
+  const totalColumnCount = 1 + activeColumns.length + 1; // checkbox + data columns + rows
 
   return (
     <TableContainer component={Paper} className={classes.tableContainer}>
@@ -305,147 +505,76 @@ const SpatialTemporalResultsTable = ({
               />
             </TableCell>
 
-            {/* Status column */}
-            <TableCell className={classes.statusCell} align="center">
-              Status
-            </TableCell>
-
-            {/* Dataset Name column - not sortable in SQL mode */}
-            <TableCell className={classes.datasetNameCell}>
-              Dataset Name
-            </TableCell>
-
-            {/* Type column with filter dropdown */}
-            <TableCell className={classes.typeCell}>
-              <Box display="flex" alignItems="center">
-                Type
-                <DataTypeFilterDropdown
-                  selectedTypes={selectedDataTypes}
-                  onSelectionChange={setSelectedDataTypes}
-                  disabled={safeResults.length === 0}
-                />
-              </Box>
-            </TableCell>
-
-            {/* TEMPORARY: Dataset Coverage - will be deleted later */}
-            <TableCell className={classes.utilizationCell} align="right">
-              <SortableHeader
-                field="datasetUtilization"
-                label={
-                  <Box
-                    component="span"
-                    display="inline-flex"
-                    alignItems="flex-start"
-                    gap={0.375}
-                  >
-                    <span>Dataset Coverage</span>
-                    <InfoTooltip
-                      title="How much of this dataset's extent is within the ROI? 100% means the entire dataset extent falls within your ROI."
-                      fontSize="small"
-                    />
-                  </Box>
-                }
-                isActive={sortMode === 'utilization'}
-                direction={sortMode === 'utilization' ? sortDirection : 'desc'}
-                uiPattern="headers-only"
-                onClick={handleHeaderClick}
-                className={classes.clickableHeader}
-              />
-            </TableCell>
-
-            {/* === COVERAGE PERCENTAGES GROUP === */}
-
-            {/* ROI Coverage - sortable */}
-            <TableCell className={classes.coverageCell} align="right">
-              <SortableHeader
-                field="spatialCoverage"
-                label={
-                  <Box
-                    component="span"
-                    display="inline-flex"
-                    alignItems="flex-start"
-                    gap={0.375}
-                  >
-                    <span>ROI Coverage</span>
-                    <InfoTooltip
-                      title="How much of the ROI does this dataset's extent cover? 100% means the dataset extent covers your entire ROI."
-                      fontSize="small"
-                    />
-                  </Box>
-                }
-                isActive={sortMode === 'spatial'}
-                direction={sortMode === 'spatial' ? sortDirection : 'desc'}
-                uiPattern="headers-only"
-                onClick={handleHeaderClick}
-                className={classes.clickableHeader}
-              />
-            </TableCell>
-
-            {/* Temporal Coverage - conditionally visible */}
-            {temporalEnabled && (
-              <TableCell className={classes.coverageCell} align="right">
-                <SortableHeader
-                  field="temporalCoverage"
-                  label="Temporal Coverage"
-                  isActive={sortMode === 'temporal'}
-                  direction={sortMode === 'temporal' ? sortDirection : 'desc'}
-                  uiPattern="headers-only"
-                  onClick={handleHeaderClick}
-                  className={classes.clickableHeader}
-                />
-              </TableCell>
-            )}
-
-            {/* Depth Coverage - conditionally visible */}
-            {depthEnabled && (
-              <TableCell className={classes.coverageCell} align="right">
-                <SortableHeader
-                  field="depthCoverage"
-                  label="Depth Coverage"
-                  isActive={sortMode === 'depth'}
-                  direction={sortMode === 'depth' ? sortDirection : 'desc'}
-                  uiPattern="headers-only"
-                  onClick={handleHeaderClick}
-                  className={classes.clickableHeader}
-                />
-              </TableCell>
-            )}
-
-            {/* === OVERLAP VALUES GROUP === */}
-
-            {/* Date Overlap - conditionally visible */}
-            {temporalEnabled && (
-              <TableCell className={classes.overlapCell}>
-                Date Overlap
-              </TableCell>
-            )}
-
-            {/* Spatial Overlap */}
-            <TableCell className={classes.overlapCell}>
-              <Box
-                component="span"
-                display="inline-flex"
-                alignItems="flex-start"
-                gap={0.375}
-              >
-                <span>Spatial Overlap</span>
-                <InfoTooltip
-                  title="The geographic bounds of the overlapping region between this dataset and your ROI."
-                  fontSize="small"
-                />
-              </Box>
-            </TableCell>
-
-            {/* Depth Overlap - conditionally visible */}
-            {depthEnabled && (
-              <TableCell className={classes.overlapCell}>
-                Depth Overlap
-              </TableCell>
-            )}
+            {/* Data columns from config */}
+            {activeColumns.map((columnKey) => {
+              const column = columnConfig[columnKey];
+              return (
+                <TableCell
+                  key={columnKey}
+                  className={column.cellClass}
+                  align={column.align}
+                >
+                  {column.header}
+                </TableCell>
+              );
+            })}
 
             {/* Rows column */}
             <TableCell className={classes.rowsCell} align="right">
-              Rows
+              <Box className={classes.rowsHeaderCell}>
+                <span>Rows</span>
+                <Box display="flex" alignItems="center" gap={0.5}>
+                  {/* Show recalculate button ONLY after a search completes, not after "Recalculate All" is used.
+                      - Results exist
+                      - User has NOT used "Recalculate All" yet (resets on new search)
+                      - Not all datasets have full coverage (indicates recalculation would be useful)
+                      - Not all counts calculated yet (indicates this is right after search, not after constraint change)
+
+                      Important: Button does NOT reappear when "Recalculate All" is clicked.
+                      User must perform a NEW SEARCH to get the "Recalculate All" button again. */}
+                  {results &&
+                    results.length > 0 &&
+                    !hasUsedGlobalRecalculation &&
+                    !allDatasetsFullCoverage &&
+                    !allCountsCalculated && (
+                      <Button
+                        variant="text"
+                        size="small"
+                        onClick={handleCalculateRowCounts}
+                        disabled={rowCountsLoading}
+                        className={classes.recalculateButton}
+                        aria-label="Recalculate row counts for all stale datasets"
+                        style={{
+                          backgroundColor: rowCountsLoading
+                            ? 'rgba(255, 255, 255, 0.2)' // Gray when calculating
+                            : '#bbdefb', // Light blue when enabled
+                          color: rowCountsLoading
+                            ? 'rgba(255, 255, 255, 0.5)' // Gray text when calculating
+                            : '#1565c0', // Dark blue text when enabled
+                        }}
+                      >
+                        {rowCountsLoading
+                          ? 'Calculating...'
+                          : 'Recalculate All'}
+                      </Button>
+                    )}
+                  <InfoTooltip
+                    title={
+                      <>
+                        Row counts show the number of rows in each dataset
+                        within your search constraints. Click 'Recalculate' to
+                        get accurate counts based on your specific region and
+                        time period.
+                        <br />
+                        <br />
+                        Note: Satellite and model datasets are excluded from
+                        calculation due to their large size.
+                      </>
+                    }
+                    fontSize="small"
+                  />
+                </Box>
+              </Box>
             </TableCell>
           </TableRow>
         </TableHead>
@@ -465,7 +594,7 @@ const SpatialTemporalResultsTable = ({
               </TableCell>
             </TableRow>
           ) : (
-            sortedResults.map((dataset, index) => {
+            sortedResults.map((dataset) => {
               const isSelected = selectedDatasetIds.has(dataset.shortName);
               const isAlreadyPresent = currentCollectionDatasetIds.has(
                 dataset.shortName,
@@ -473,7 +602,7 @@ const SpatialTemporalResultsTable = ({
               const rowClass = getRowClass(dataset);
 
               return (
-                <TableRow key={index} className={rowClass}>
+                <TableRow key={dataset.shortName} className={rowClass}>
                   {/* Selection checkbox */}
                   <TableCell
                     className={`${classes.tableCell} ${classes.checkboxCell}`}
@@ -487,150 +616,32 @@ const SpatialTemporalResultsTable = ({
                     />
                   </TableCell>
 
-                  {/* Status icon */}
-                  <TableCell
-                    className={`${classes.tableCell} ${classes.statusCell}`}
-                    align="center"
-                  >
-                    {getStatusIcon(
-                      isAlreadyPresent
-                        ? ROW_STATES.ALREADY_PRESENT
-                        : ROW_STATES.NORMAL,
-                    )}
-                  </TableCell>
+                  {/* Data columns from config */}
+                  {activeColumns.map((columnKey) => {
+                    const column = columnConfig[columnKey];
+                    return (
+                      <TableCell
+                        key={columnKey}
+                        className={`${classes.tableCell} ${column.cellClass}`}
+                        align={column.align}
+                      >
+                        {column.render(dataset)}
+                      </TableCell>
+                    );
+                  })}
 
-                  {/* Dataset Name with description */}
-                  <TableCell
-                    className={`${classes.tableCell} ${classes.datasetNameCell}`}
-                  >
-                    <Box>
-                      <DatasetNameLink
-                        datasetShortName={dataset.shortName}
-                        typographyProps={{
-                          variant: 'body2',
-                          noWrap: true,
-                        }}
-                      />
-                      {dataset.longName && (
-                        <Typography className={classes.datasetDescription}>
-                          {dataset.longName}
-                        </Typography>
-                      )}
-                    </Box>
-                  </TableCell>
-
-                  {/* Type */}
-                  <TableCell
-                    className={`${classes.tableCell} ${classes.typeCell}`}
-                  >
-                    {dataset.type || 'N/A'}
-                  </TableCell>
-
-                  {/* TEMPORARY: Dataset Utilization - will be deleted later */}
-                  <TableCell
-                    className={`${classes.tableCell} ${classes.utilizationCell}`}
-                    align="right"
-                  >
-                    {typeof dataset.datasetUtilization === 'number'
-                      ? (() => {
-                          const percent = dataset.datasetUtilization * 100;
-                          const rounded = parseFloat(percent.toFixed(1));
-                          if (rounded === 0 && dataset.datasetUtilization > 0) {
-                            return '< 0.05%';
-                          }
-                          return `${rounded.toFixed(1)}%`;
-                        })()
-                      : 'N/A'}
-                  </TableCell>
-
-                  {/* === COVERAGE PERCENTAGES GROUP === */}
-
-                  {/* Spatial Coverage % */}
-                  <TableCell
-                    className={`${classes.tableCell} ${classes.coverageCell}`}
-                    align="right"
-                  >
-                    {typeof dataset.overlap.spatial.coveragePercent === 'number'
-                      ? `${Math.round(dataset.overlap.spatial.coveragePercent * 100)}%`
-                      : dataset.overlap.spatial.coveragePercent}
-                  </TableCell>
-
-                  {/* Temporal Coverage % - conditionally visible */}
-                  {temporalEnabled && (
-                    <TableCell
-                      className={`${classes.tableCell} ${classes.coverageCell}`}
-                      align="right"
-                    >
-                      {dataset.overlap.temporal
-                        ? typeof dataset.overlap.temporal.coveragePercent ===
-                          'number'
-                          ? `${Math.round(dataset.overlap.temporal.coveragePercent * 100)}%`
-                          : dataset.overlap.temporal.coveragePercent
-                        : 'N/A'}
-                    </TableCell>
-                  )}
-
-                  {/* Depth Coverage % - conditionally visible */}
-                  {depthEnabled && (
-                    <TableCell
-                      className={`${classes.tableCell} ${classes.coverageCell}`}
-                      align="right"
-                    >
-                      {dataset.overlap.depth
-                        ? typeof dataset.overlap.depth.coveragePercent ===
-                          'number'
-                          ? `${Math.round(dataset.overlap.depth.coveragePercent * 100)}%`
-                          : dataset.overlap.depth.coveragePercent
-                        : 'N/A'}
-                    </TableCell>
-                  )}
-
-                  {/* === OVERLAP VALUES GROUP === */}
-
-                  {/* Date Overlap - conditionally visible */}
-                  {temporalEnabled && (
-                    <TableCell
-                      className={`${classes.tableCell} ${classes.overlapCell}`}
-                    >
-                      {dataset.overlap.temporal
-                        ? dataset.overlap.temporal.range
-                        : 'N/A'}
-                    </TableCell>
-                  )}
-
-                  {/* Spatial Overlap */}
-                  <TableCell
-                    className={`${classes.tableCell} ${classes.overlapCell}`}
-                  >
-                    {dataset.overlap.spatial.extent
-                      .split('\n')
-                      .map((line, index, array) => (
-                        <React.Fragment key={index}>
-                          {line}
-                          {index < array.length - 1 && <br />}
-                        </React.Fragment>
-                      ))}
-                  </TableCell>
-
-                  {/* Depth Overlap - conditionally visible */}
-                  {depthEnabled && (
-                    <TableCell
-                      className={`${classes.tableCell} ${classes.overlapCell}`}
-                    >
-                      {dataset.overlap.depth
-                        ? dataset.overlap.depth.range
-                        : 'N/A'}
-                    </TableCell>
-                  )}
-
-                  {/* Rows */}
+                  {/* Rows column with calculated/original/failed/skipped states */}
                   <TableCell
                     className={`${classes.tableCell} ${classes.rowsCell}`}
                     align="right"
                   >
-                    {typeof dataset.rows === 'number'
-                      ? dataset.rows.toLocaleString()
-                      : 'N/A'}
+                    <RowCountCell
+                      dataset={dataset}
+                      calculatedRowCounts={calculatedRowCounts}
+                      failedRowCounts={failedRowCounts}
+                      skippedDatasets={skippedDatasets}
+                      rowCountLoadingDatasets={rowCountLoadingDatasets}
+                    />
                   </TableCell>
                 </TableRow>
               );
@@ -661,6 +672,7 @@ SpatialTemporalResultsTable.propTypes = {
             PropTypes.string,
           ]),
           range: PropTypes.string,
+          utilization: PropTypes.number, // NEW
         }),
         depth: PropTypes.shape({
           coveragePercent: PropTypes.oneOfType([
@@ -668,6 +680,10 @@ SpatialTemporalResultsTable.propTypes = {
             PropTypes.string,
           ]),
           range: PropTypes.string,
+          utilization: PropTypes.oneOfType([
+            PropTypes.number,
+            PropTypes.oneOf([null]),
+          ]), // NEW
         }),
       }).isRequired,
     }),

--- a/src/features/collections/addDatasets/SpatialTemporalTab/components/StaleIndicatorTooltip.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/components/StaleIndicatorTooltip.js
@@ -1,0 +1,205 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip, Button, Box, CircularProgress } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import zIndex from '../../../../../enums/zIndex';
+import logInit from '../../../../../Services/log-service';
+
+const log = logInit('SpatialTemporalTab/StaleIndicatorTooltip');
+
+const useStyles = makeStyles(() => ({
+  tooltip: {
+    maxWidth: 300,
+    backgroundColor: 'rgba(30, 67, 113, 0.95)',
+    fontSize: 12,
+    padding: 12,
+    borderRadius: 4,
+    zIndex: zIndex.MODAL_LAYER_2_POPPER, // Ensure tooltip appears above AddDatasetsModal (SECONDARY_MODAL)
+  },
+  tooltipContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 14,
+  },
+  body: {
+    fontSize: 12,
+    lineHeight: 1.5,
+  },
+  action: {
+    fontSize: 12,
+    lineHeight: 1.5,
+  },
+  button: {
+    backgroundColor: '#bbdefb',
+    color: '#1565c0',
+    fontWeight: 700,
+    fontSize: '0.75rem',
+    textTransform: 'none',
+    marginTop: 4,
+    marginBottom: 4,
+    '&:hover': {
+      backgroundColor: '#90caf9',
+    },
+    '&:disabled': {
+      backgroundColor: '#e3f2fd',
+      color: '#64b5f6',
+    },
+  },
+  footer: {
+    fontSize: 11,
+    color: 'rgba(255, 255, 255, 0.7)',
+    fontStyle: 'italic',
+  },
+  spinner: {
+    marginLeft: 8,
+  },
+}));
+
+/**
+ * Tooltip message templates for different staleness reasons
+ * Each reason has two variants:
+ * - body: Shown when recalculate button is available
+ * - bodyAfterRecalculation: Shown when user has already used "Recalculate All" (button hidden)
+ */
+const TOOLTIP_MESSAGES = {
+  spatial_partial: {
+    body: 'This row count may not reflect your current constraints. Click Recalculate to get an accurate count.',
+    bodyAfterRecalculation:
+      'This row count may not reflect your current constraints. To get accurate counts, you must first perform a new search with your updated constraints, then recalculate.',
+  },
+  temporal_enabled: {
+    body: 'This row count may not reflect your current constraints. Click Recalculate to get an accurate count.',
+    bodyAfterRecalculation:
+      'This row count may not reflect your current constraints. To get accurate counts, you must first perform a new search with your updated constraints, then recalculate.',
+  },
+  depth_enabled: {
+    body: 'This row count may not reflect your current constraints. Click Recalculate to get an accurate count.',
+    bodyAfterRecalculation:
+      'This row count may not reflect your current constraints. To get accurate counts, you must first perform a new search with your updated constraints, then recalculate.',
+  },
+  constraints_changed: {
+    body: 'This row count may not reflect your current constraints. Click Recalculate to get an accurate count.',
+    bodyAfterRecalculation:
+      'This row count may not reflect your current constraints. To get accurate counts, you must first perform a new search with your updated constraints, then recalculate.',
+  },
+  dataset_not_in_results: {
+    body: 'Search results changed - this dataset may no longer match your current constraints. Click Recalculate to confirm this dataset still matches.',
+    bodyAfterRecalculation:
+      'Search results changed - this dataset may no longer match your current constraints. To get accurate counts, you must first perform a new search with your updated constraints, then recalculate.',
+  },
+};
+
+/**
+ * StaleIndicatorTooltip Component
+ *
+ * Displays a tooltip with an explanation and optionally an embedded recalculate button
+ * when a dataset's row count is stale (does not reflect current constraints).
+ *
+ * @param {Object} props
+ * @param {string} props.reason - Staleness reason ('spatial_partial', 'temporal_enabled', 'depth_enabled', 'constraints_changed', 'dataset_not_in_results')
+ * @param {Object} props.dataset - Dataset object with shortName
+ * @param {Function} props.onRecalculate - Callback to trigger recalculation for this dataset
+ * @param {boolean} props.isRecalculating - Whether recalculation is in progress
+ * @param {boolean} props.hasUsedGlobalRecalculation - Whether the user has already used the "Recalculate All" button
+ * @param {React.ReactNode} props.children - The warning icon element
+ * @returns {JSX.Element}
+ */
+const StaleIndicatorTooltip = ({
+  reason,
+  dataset,
+  onRecalculate,
+  isRecalculating,
+  hasUsedGlobalRecalculation,
+  children,
+}) => {
+  const classes = useStyles();
+  const message = TOOLTIP_MESSAGES[reason];
+
+  // Fallback for unknown reason
+  if (!message) {
+    log.warn(
+      `StaleIndicatorTooltip: Unknown reason "${reason}" for dataset ${dataset.shortName}`,
+      { reason, dataset: dataset.shortName },
+    );
+    return children;
+  }
+
+  const handleRecalculate = (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+    onRecalculate();
+  };
+
+  // Select appropriate message based on whether recalculate button is available
+  const messageText = hasUsedGlobalRecalculation
+    ? message.bodyAfterRecalculation
+    : message.body;
+
+  const tooltipContent = (
+    <Box className={classes.tooltipContent}>
+      <div className={classes.body}>{messageText}</div>
+      {/* Only show recalculate button if user hasn't used "Recalculate All" yet */}
+      {!hasUsedGlobalRecalculation && (
+        <Button
+          className={classes.button}
+          size="small"
+          variant="contained"
+          onClick={handleRecalculate}
+          disabled={isRecalculating}
+          aria-label="Recalculate row count for this dataset"
+        >
+          {isRecalculating ? (
+            <>
+              Recalculating...
+              <CircularProgress
+                size={12}
+                className={classes.spinner}
+                color="inherit"
+              />
+            </>
+          ) : (
+            'Recalculate'
+          )}
+        </Button>
+      )}
+    </Box>
+  );
+
+  return (
+    <Tooltip
+      title={tooltipContent}
+      classes={{ tooltip: classes.tooltip }}
+      placement="top"
+      interactive
+      aria-describedby={`stale-tooltip-${dataset.shortName}`}
+      PopperProps={{
+        style: { zIndex: zIndex.MODAL_LAYER_2_POPPER },
+      }}
+    >
+      <span aria-label="Warning: Row count may be inaccurate">{children}</span>
+    </Tooltip>
+  );
+};
+
+StaleIndicatorTooltip.propTypes = {
+  reason: PropTypes.oneOf([
+    'spatial_partial',
+    'temporal_enabled',
+    'depth_enabled',
+    'constraints_changed',
+    'dataset_not_in_results',
+  ]).isRequired,
+  dataset: PropTypes.shape({
+    shortName: PropTypes.string.isRequired,
+  }).isRequired,
+  onRecalculate: PropTypes.func.isRequired,
+  isRecalculating: PropTypes.bool.isRequired,
+  hasUsedGlobalRecalculation: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default StaleIndicatorTooltip;

--- a/src/features/collections/addDatasets/SpatialTemporalTab/components/TemporalConstraintsInput.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/components/TemporalConstraintsInput.js
@@ -127,25 +127,55 @@ const TemporalConstraintsInput = () => {
     }
   };
 
+  // Track local state for date inputs
+  const [localTemporalRange, setLocalTemporalRange] =
+    React.useState(temporalRange);
+
+  // Sync local state with store when store changes
+  React.useEffect(() => {
+    setLocalTemporalRange(temporalRange);
+  }, [temporalRange]);
+
   /**
-   * Handle date input changes
+   * Handle date input changes - validate immediately but don't update store
    * @param {string} field - Field name ('timeMin' or 'timeMax')
    * @param {Date|null} value - Date object value
    */
   const handleDateChange = (field, value) => {
-    // Update store with new value
+    // Update local state only
     const updatedRange = {
-      ...temporalRange,
+      ...localTemporalRange,
       [field]: value,
     };
-    setTemporalConstraints(temporalEnabled, updatedRange);
+    setLocalTemporalRange(updatedRange);
 
-    // Validate
+    // Validate (show errors immediately)
     const newErrors = validateRange(
-      field === 'timeMin' ? value : temporalRange.timeMin,
-      field === 'timeMax' ? value : temporalRange.timeMax,
+      field === 'timeMin' ? value : localTemporalRange.timeMin,
+      field === 'timeMax' ? value : localTemporalRange.timeMax,
     );
     setErrors(newErrors);
+  };
+
+  /**
+   * Handle blur events - update store only when user finishes editing
+   * This prevents premature constraint snapshot comparisons during typing
+   */
+  const handleBlur = () => {
+    if (!temporalEnabled) {
+      return;
+    }
+
+    // Validate before updating store
+    const newErrors = validateRange(
+      localTemporalRange.timeMin,
+      localTemporalRange.timeMax,
+    );
+
+    // Only update store if valid
+    if (!newErrors.timeMin && !newErrors.timeMax) {
+      setTemporalConstraints(temporalEnabled, localTemporalRange);
+    }
   };
 
   return (
@@ -175,16 +205,18 @@ const TemporalConstraintsInput = () => {
           <Box className={classes.inputsRow}>
             <DateInput
               label="Start Date"
-              value={temporalRange.timeMin}
+              value={localTemporalRange.timeMin}
               onChange={(date) => handleDateChange('timeMin', date)}
+              onBlur={handleBlur}
               validationMessage={errors.timeMin}
               width={140}
             />
 
             <DateInput
               label="End Date"
-              value={temporalRange.timeMax}
+              value={localTemporalRange.timeMax}
               onChange={(date) => handleDateChange('timeMax', date)}
+              onBlur={handleBlur}
               validationMessage={errors.timeMax}
               width={140}
             />

--- a/src/features/collections/addDatasets/SpatialTemporalTab/index.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/index.js
@@ -13,6 +13,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
 import {
   Box,
   Typography,
@@ -30,8 +31,8 @@ import OverlapModeCheckbox from './components/OverlapModeCheckbox';
 import SpatialTemporalResultsTable from './components/SpatialTemporalResultsTable';
 import ConstraintsSummary from './components/ConstraintsSummary';
 import UniversalButton from '../../../../shared/components/UniversalButton';
-import SingleStatistic from '../../components/SingleStatistic';
 import DiagnosticQuery from './DiagnosticQuery';
+import { snackbarOpen } from '../../../../Redux/actions/ui';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -119,12 +120,6 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     flexWrap: 'wrap',
   },
-  statisticsWrapper: {
-    flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    minHeight: '42px', // Match the height of the checkbox/button row
-  },
   resultsSection: {
     display: 'flex',
     flexDirection: 'column',
@@ -159,6 +154,27 @@ const useStyles = makeStyles((theme) => ({
       justifyContent: 'center',
     },
   },
+  rowCountButton: {
+    minWidth: '180px',
+  },
+  warningMessage: {
+    fontSize: '0.875rem',
+    color: theme.palette.text.secondary,
+    fontStyle: 'italic',
+    maxWidth: '400px',
+  },
+  rowCountSection: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(2),
+  },
+  rowCountButtonRow: {
+    display: 'flex',
+    gap: theme.spacing(2),
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
 }));
 
 /**
@@ -183,6 +199,7 @@ const SpatialTemporalTab = ({
   onConstraintsChange,
 }) => {
   const classes = useStyles();
+  const dispatch = useDispatch();
 
   // Connect to spatialTemporalSearchStore
   const {
@@ -227,12 +244,33 @@ const SpatialTemporalTab = ({
     }).length;
   }, [results, currentCollectionDatasetIds, selectedDataTypes]);
 
+  // Check if results contain satellite or model datasets
+  const hasSatelliteOrModelDatasets = React.useMemo(() => {
+    if (!results || results.length === 0) return false;
+
+    return results.some(
+      (dataset) => dataset.type === 'Satellite' || dataset.type === 'Model',
+    );
+  }, [results]);
+
   // Initialize catalog search on mount
   useEffect(() => {
     if (!isInitialized && !isInitializing) {
       initialize();
     }
   }, [initialize, isInitialized, isInitializing]);
+
+  // Show error snackbar when search fails
+  useEffect(() => {
+    if (searchError) {
+      dispatch(
+        snackbarOpen({
+          message: `Search failed: ${searchError}. Please try again.`,
+          severity: 'error',
+        }),
+      );
+    }
+  }, [searchError, dispatch]);
 
   // Notify parent component when results count changes
   useEffect(() => {
@@ -330,7 +368,7 @@ const SpatialTemporalTab = ({
               </Box>
             </Box>
 
-            {/* Search Button Row: Left side = Search button + checkbox, Right side = Statistics */}
+            {/* Search Button Row */}
             <Box className={classes.searchButtonRow}>
               <Box className={classes.searchButtonGroup}>
                 <UniversalButton
@@ -352,22 +390,6 @@ const SpatialTemporalTab = ({
                 </UniversalButton>
                 <OverlapModeCheckbox />
               </Box>
-
-              {/* Statistics - Show when there are results and items already in collection */}
-              {results &&
-                results.length > 0 &&
-                alreadyInCollectionCount > 0 && (
-                  <Box className={classes.statisticsWrapper}>
-                    <SingleStatistic
-                      value={alreadyInCollectionCount}
-                      label="Already in Collection"
-                      borderColor="rgba(128, 128, 128, 0.6)"
-                      compact
-                      maxWidth="280px"
-                      noEllipsis
-                    />
-                  </Box>
-                )}
             </Box>
           </Box>
         </Collapse>

--- a/src/features/collections/addDatasets/SpatialTemporalTab/store/rowCountCalculationStore.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/store/rowCountCalculationStore.js
@@ -1,0 +1,612 @@
+import { create } from 'zustand';
+import collectionsAPI from '../../../api/collectionsApi';
+import { areConstraintsEqual } from '../utils/constraintComparison';
+import { isValidTemporalRange, isValidDepthRange } from '../utils/validation';
+import useSpatialTemporalSearchStore from './spatialTemporalSearchStore';
+import logInit from '../../../../../Services/log-service';
+import isEligibleForEstimation from '../../../../../shared/estimation/isEligibleForEstimation';
+import estimateRowCount from '../../../../../shared/estimation/estimateRowCount';
+import { getSearchDatabaseApi } from '../../../../catalogSearch/api';
+
+const log = logInit('SpatialTemporalTab/rowCountCalculationStore');
+
+/**
+ * Zustand store managing row count calculation state and actions.
+ *
+ * This store provides centralized state management for:
+ * - Row count calculation results for datasets
+ * - Loading states for individual datasets
+ * - Error handling and skipped datasets (satellite/model types)
+ *
+ * Separated from spatialTemporalSearchStore to isolate row count concerns.
+ *
+ * @module rowCountCalculationStore
+ */
+
+const useRowCountCalculationStore = create((set, get) => ({
+  // ===========================================
+  // State Fields
+  // ===========================================
+
+  /**
+   * Row count calculation state
+   */
+  calculatedRowCounts: {}, // Map of shortName → count
+  rowCountsLoading: false,
+  rowCountLoadingDatasets: new Set(), // Set of shortNames currently being calculated
+  rowCountError: null,
+  skippedDatasets: [], // Array of shortNames for cluster-only datasets that were skipped
+  failedRowCounts: [], // Datasets that failed calculation
+  estimatedRowCounts: new Set(), // Set of shortNames that were calculated via frontend estimation (vs backend recalculation)
+
+  /**
+   * Per-dataset constraint snapshots capturing constraint state when each dataset's row count was calculated.
+   * Used to detect when current constraints differ from the constraints used for that specific dataset,
+   * enabling per-dataset staleness detection for cached row counts.
+   *
+   * Structure: Map of shortName → snapshot object
+   * Each snapshot contains:
+   * @property {Object} spatialBounds - Spatial bounds at calculation time
+   * @property {number} spatialBounds.latMin - Minimum latitude
+   * @property {number} spatialBounds.latMax - Maximum latitude
+   * @property {number} spatialBounds.lonMin - Minimum longitude
+   * @property {number} spatialBounds.lonMax - Maximum longitude
+   * @property {Object} temporalRange - Temporal range at calculation time
+   * @property {Date|null} temporalRange.timeMin - Start date
+   * @property {Date|null} temporalRange.timeMax - End date
+   * @property {Object} depthRange - Depth range at calculation time
+   * @property {number|null} depthRange.depthMin - Minimum depth in meters
+   * @property {number|null} depthRange.depthMax - Maximum depth in meters
+   * @property {boolean} temporalEnabled - Whether temporal constraints were active
+   * @property {boolean} depthEnabled - Whether depth constraints were active
+   * @property {boolean} includePartialOverlaps - Whether partial overlap mode was enabled
+   * @property {Date} timestamp - When the calculation was performed
+   *
+   * @type {Object} - Map of shortName → snapshot (empty object {} before any calculations)
+   */
+  datasetConstraintSnapshots: {},
+
+  /**
+   * Tracks whether the user has used the "Recalculate All" button for the current search.
+   * This flag only tracks GLOBAL recalculation, not individual dataset recalculations.
+   * Reset only when a new search is performed (clearRowCounts called).
+   *
+   * @type {boolean}
+   */
+  hasUsedGlobalRecalculation: false,
+
+  /**
+   * Tracks dataset IDs from the last successful search.
+   * Used to detect if a dataset is no longer in the current search results,
+   * which indicates the calculated row count may be stale.
+   *
+   * @type {Set<string>} - Set of dataset short names from last search
+   */
+  lastSearchDatasetIds: new Set(),
+
+  // ===========================================
+  // Selectors
+  // ===========================================
+
+  /**
+   * Determines if a dataset's row count is stale based on current constraints
+   * and per-dataset recalculation history.
+   *
+   * Staleness detection rules:
+   * - Satellite/Model datasets: Never stale (excluded from recalculation)
+   * - Dataset not in search results: Stale if has calculated row count (search results changed)
+   * - No snapshot for this dataset: Stale if temporal/depth enabled WITH VALID VALUES OR spatial partial coverage
+   * - Snapshot exists for this dataset: Stale if current constraints differ from dataset's snapshot
+   *
+   * @param {string} shortName - Dataset identifier
+   * @param {Object} currentConstraints - Current constraint configuration
+   * @param {Object} currentConstraints.spatialBounds - Spatial bounds { latMin, latMax, lonMin, lonMax }
+   * @param {Object} currentConstraints.temporalRange - Temporal range { timeMin: Date|null, timeMax: Date|null }
+   * @param {Object} currentConstraints.depthRange - Depth range { depthMin: number|null, depthMax: number|null }
+   * @param {boolean} currentConstraints.temporalEnabled - Whether temporal constraints are active
+   * @param {boolean} currentConstraints.depthEnabled - Whether depth constraints are active
+   * @param {boolean} currentConstraints.includePartialOverlaps - Whether partial overlap mode is enabled
+   * @param {number} datasetUtilization - Dataset's spatial utilization metric (0.0 to 1.0)
+   * @param {string} datasetType - Dataset type (e.g., 'Satellite', 'Model', 'In-Situ')
+   * @returns {{ isStale: boolean, reason: string|null }} Staleness state and reason
+   *
+   * @example
+   * const { isStale, reason } = get().isDatasetStale(
+   *   'dataset_1',
+   *   currentConstraints,
+   *   0.85,
+   *   'In-Situ'
+   * );
+   * // Returns { isStale: true, reason: 'spatial_partial' }
+   */
+  isDatasetStale: (
+    shortName,
+    currentConstraints,
+    datasetUtilization,
+    datasetType,
+  ) => {
+    const {
+      datasetConstraintSnapshots,
+      calculatedRowCounts,
+      lastSearchDatasetIds,
+    } = get();
+    const datasetSnapshot = datasetConstraintSnapshots[shortName];
+
+    // Check if dataset is no longer in current search results but has a calculated row count
+    // This means search results changed and the calculated value may no longer be relevant
+    if (lastSearchDatasetIds.size > 0 && !lastSearchDatasetIds.has(shortName)) {
+      // Only mark as stale if we have a calculated row count for this dataset
+      if (calculatedRowCounts[shortName] !== undefined) {
+        log.debug('Dataset stale', {
+          shortName,
+          reason: 'dataset_not_in_results',
+        });
+        return { isStale: true, reason: 'dataset_not_in_results' };
+      }
+    }
+
+    // Case 1: No recalculation has been performed for this dataset yet
+    if (!datasetSnapshot) {
+      // Temporal enabled with valid values: stale (no utilization metrics available)
+      if (currentConstraints.temporalEnabled) {
+        const temporalConstraints = {
+          enabled: true,
+          ...currentConstraints.temporalRange,
+        };
+        if (isValidTemporalRange(temporalConstraints)) {
+          log.debug('Dataset stale', { shortName, reason: 'temporal_enabled' });
+          return { isStale: true, reason: 'temporal_enabled' };
+        }
+      }
+
+      // Depth enabled with valid values: stale (no utilization metrics available)
+      if (currentConstraints.depthEnabled) {
+        const depthConstraints = {
+          enabled: true,
+          ...currentConstraints.depthRange,
+        };
+        if (isValidDepthRange(depthConstraints)) {
+          log.debug('Dataset stale', { shortName, reason: 'depth_enabled' });
+          return { isStale: true, reason: 'depth_enabled' };
+        }
+      }
+
+      // Spatial-only: stale if partial coverage (< 1.0)
+      if (datasetUtilization < 1.0) {
+        log.debug('Dataset stale', { shortName, reason: 'spatial_partial' });
+        return { isStale: true, reason: 'spatial_partial' };
+      }
+
+      // Full spatial coverage with no temporal/depth: not stale
+      return { isStale: false, reason: null };
+    }
+
+    // Case 2: Dataset snapshot exists
+    // First check if current constraints are valid
+    // Invalid constraints can't make row counts stale (nothing to recalculate with)
+    if (currentConstraints.temporalEnabled) {
+      const temporalConstraints = {
+        enabled: true,
+        ...currentConstraints.temporalRange,
+      };
+      if (!isValidTemporalRange(temporalConstraints)) {
+        return { isStale: false, reason: null };
+      }
+    }
+
+    if (currentConstraints.depthEnabled) {
+      const depthConstraints = {
+        enabled: true,
+        ...currentConstraints.depthRange,
+      };
+      if (!isValidDepthRange(depthConstraints)) {
+        return { isStale: false, reason: null };
+      }
+    }
+
+    // Now compare valid constraints against snapshot
+    const constraintsMatch = areConstraintsEqual(
+      currentConstraints,
+      datasetSnapshot,
+    );
+
+    log.debug('Constraint equality check', {
+      shortName,
+      isEqual: constraintsMatch,
+      current: currentConstraints,
+      snapshot: datasetSnapshot,
+    });
+
+    if (!constraintsMatch) {
+      log.debug('Dataset stale', { shortName, reason: 'constraints_changed' });
+      return { isStale: true, reason: 'constraints_changed' };
+    }
+
+    // Constraints match dataset's snapshot: row count is still valid
+    return { isStale: false, reason: null };
+  },
+
+  /**
+   * Check if a dataset was skipped (cluster-only) during row count calculation.
+   *
+   * @param {string} shortName - Dataset identifier
+   * @returns {boolean} True if dataset was skipped, false otherwise
+   *
+   * @example
+   * const isSkipped = get().isDatasetSkipped('dataset_1');
+   * // Returns true if dataset is cluster-only
+   */
+  isDatasetSkipped: (shortName) => {
+    const { skippedDatasets } = get();
+    return skippedDatasets.includes(shortName);
+  },
+
+  // ===========================================
+  // Actions
+  // ===========================================
+
+  /**
+   * Helper function that builds constraints object from current store state.
+   * Used to get constraints from the spatialTemporalSearchStore.
+   *
+   * @returns {Object} Constraints object with all constraint fields
+   */
+  buildConstraintsFromStore: () => {
+    const {
+      spatialBounds,
+      temporalRange,
+      depthRange,
+      temporalEnabled,
+      depthEnabled,
+      includePartialOverlaps,
+    } = useSpatialTemporalSearchStore.getState();
+
+    return {
+      spatialBounds,
+      temporalRange,
+      depthRange,
+      temporalEnabled,
+      depthEnabled,
+      includePartialOverlaps,
+    };
+  },
+
+  /**
+   * Calculate row counts for specific datasets.
+   * Pure execution function - no staleness filtering.
+   * Always stores per-dataset constraint snapshots for calculated datasets.
+   *
+   * Uses frontend estimation for eligible datasets (regular gridded, Darwin/PISCES depth).
+   * Sends remaining datasets to backend for calculation in a single bulk request.
+   *
+   * @param {Array<Object>} datasets - Array of dataset objects with metadata
+   * @param {Object} constraints - Constraint configuration
+   * @param {Object} constraints.spatialBounds - Spatial bounds { latMin, latMax, lonMin, lonMax }
+   * @param {Object} constraints.temporalRange - Temporal range { timeMin: Date|null, timeMax: Date|null }
+   * @param {Object} constraints.depthRange - Depth range { depthMin: number|null, depthMax: number|null }
+   * @param {boolean} constraints.temporalEnabled - Whether temporal constraints are active
+   * @param {boolean} constraints.depthEnabled - Whether depth constraints are active
+   * @param {boolean} constraints.includePartialOverlaps - Whether partial overlap mode is enabled
+   * @param {Array<string>} skippedDatasets - Array of dataset short names that were skipped (satellite/model)
+   * @returns {Promise<void>}
+   */
+  calculateRowCountsForDatasets: async (
+    datasets,
+    constraints,
+    skippedDatasets = [],
+  ) => {
+    // Can't calculate if no datasets
+    if (!datasets || datasets.length === 0) {
+      set({
+        calculatedRowCounts: {},
+        skippedDatasets: skippedDatasets,
+        failedRowCounts: [],
+        rowCountsLoading: false,
+        rowCountLoadingDatasets: new Set(),
+      });
+      return;
+    }
+
+    // Mark all datasets as loading
+    const shortNames = datasets.map((d) => d.shortName);
+    const loadingSet = new Set(shortNames);
+    set({ rowCountLoadingDatasets: loadingSet });
+
+    // Start loading
+    set({ rowCountsLoading: true, rowCountError: null });
+
+    try {
+      // Get catalog database API for estimation
+      const catalogDb = getSearchDatabaseApi();
+
+      // Separate eligible vs non-eligible datasets
+      const estimated = [];
+      const needBackend = [];
+
+      for (const dataset of datasets) {
+        try {
+          // Extract metadata fields (backend converts to camelCase before storing in SQLite)
+          const spatialResolution = dataset.metadata.spatialResolution;
+          const temporalResolution = dataset.metadata.temporalResolution;
+          const tableName = dataset.metadata.tableName || dataset.shortName;
+
+          // Check eligibility (pure, synchronous, fast)
+          const eligible = isEligibleForEstimation(
+            {
+              spatialResolution,
+              temporalResolution,
+              tableName,
+            },
+            constraints,
+          );
+
+          if (eligible) {
+            // Build dataset metadata object for estimation
+            const datasetMetadata = {
+              Spatial_Resolution: spatialResolution,
+              Temporal_Resolution: temporalResolution,
+              Table_Name: tableName,
+            };
+
+            // Estimate row count (async, uses catalogDb)
+            const count = await estimateRowCount(
+              datasetMetadata,
+              constraints,
+              catalogDb,
+            );
+            estimated.push({ shortName: dataset.shortName, rowCount: count });
+            log.debug('estimated row count', {
+              shortName: dataset.shortName,
+              count,
+            });
+          } else {
+            needBackend.push(dataset.shortName);
+            log.debug('dataset not eligible for estimation, will use backend', {
+              shortName: dataset.shortName,
+            });
+          }
+        } catch (error) {
+          // Estimation failed, fallback to backend
+          log.error('estimation failed, falling back to backend', {
+            shortName: dataset.shortName,
+            error: error.message,
+          });
+          needBackend.push(dataset.shortName);
+        }
+      }
+
+      // === PHASE 1: Apply estimated results immediately ===
+      if (estimated.length > 0) {
+        log.debug('applying estimated row counts immediately', {
+          count: estimated.length,
+        });
+
+        // Build estimated row counts object
+        const estimatedRowCounts = {};
+        estimated.forEach((e) => {
+          estimatedRowCounts[e.shortName] = e.rowCount;
+        });
+
+        // Build snapshots for estimated datasets
+        const estimatedSnapshots = { ...get().datasetConstraintSnapshots };
+        estimated.forEach((e) => {
+          const snapshot = {
+            spatialBounds: { ...constraints.spatialBounds },
+            temporalRange: { ...constraints.temporalRange },
+            depthRange: { ...constraints.depthRange },
+            temporalEnabled: constraints.temporalEnabled,
+            depthEnabled: constraints.depthEnabled,
+            includePartialOverlaps: constraints.includePartialOverlaps,
+            timestamp: new Date(),
+          };
+          estimatedSnapshots[e.shortName] = snapshot;
+          log.debug('estimation snapshot captured', {
+            shortName: e.shortName,
+            snapshot,
+          });
+        });
+
+        // Remove estimated datasets from loading set (they're done)
+        const updatedLoadingSet = new Set(
+          [...loadingSet].filter((name) => !estimated.some((e) => e.shortName === name)),
+        );
+
+        // Track which datasets were estimated (for purple label)
+        const newEstimatedSet = new Set(get().estimatedRowCounts);
+        estimated.forEach((e) => newEstimatedSet.add(e.shortName));
+
+        // Apply estimated results immediately
+        set({
+          calculatedRowCounts: {
+            ...get().calculatedRowCounts,
+            ...estimatedRowCounts,
+          },
+          datasetConstraintSnapshots: estimatedSnapshots,
+          estimatedRowCounts: newEstimatedSet,
+          rowCountLoadingDatasets: updatedLoadingSet,
+          // If no backend datasets, we're fully done
+          rowCountsLoading: needBackend.length > 0,
+        });
+      }
+
+      // === PHASE 2: Send backend request for non-eligible datasets (single bulk call) ===
+      let data = { results: {}, skipped: [], failed: [] };
+
+      if (needBackend.length > 0) {
+        log.debug('sending backend request for non-eligible datasets', {
+          count: needBackend.length,
+        });
+
+        // Build constraints object matching backend format
+        const backendConstraints = {
+          spatial: {
+            latMin: constraints.spatialBounds.latMin,
+            latMax: constraints.spatialBounds.latMax,
+            lonMin: constraints.spatialBounds.lonMin,
+            lonMax: constraints.spatialBounds.lonMax,
+          },
+        };
+
+        if (
+          constraints.temporalEnabled &&
+          constraints.temporalRange.timeMin &&
+          constraints.temporalRange.timeMax
+        ) {
+          backendConstraints.temporal = {
+            startDate: constraints.temporalRange.timeMin
+              .toISOString()
+              .split('T')[0],
+            endDate: constraints.temporalRange.timeMax
+              .toISOString()
+              .split('T')[0],
+          };
+        }
+
+        if (
+          constraints.depthEnabled &&
+          constraints.depthRange.depthMin !== null &&
+          constraints.depthRange.depthMax !== null
+        ) {
+          backendConstraints.spatial.depthMin = constraints.depthRange.depthMin;
+          backendConstraints.spatial.depthMax = constraints.depthRange.depthMax;
+        }
+
+        const response = await collectionsAPI.calculateRowCounts(
+          needBackend,
+          backendConstraints,
+        );
+
+        if (!response.ok) {
+          throw new Error('Failed to calculate row counts');
+        }
+
+        data = await response.json();
+      }
+
+      // Merge skipped datasets from frontend filter with any from backend
+      // Backend returns array of shortNames for cluster-only datasets
+      const backendSkipped = Array.isArray(data.skipped) ? data.skipped : [];
+      const allSkippedDatasets = Array.from(
+        new Set([...skippedDatasets, ...backendSkipped]),
+      );
+
+      // Store per-dataset snapshots for backend-calculated datasets only
+      // (Estimated datasets already have snapshots from Phase 1)
+      const backendSnapshots = { ...get().datasetConstraintSnapshots };
+      Object.keys(data.results).forEach((shortName) => {
+        // Only store snapshot if calculation was successful (not failed/skipped)
+        if (
+          !data.failed.includes(shortName) &&
+          !allSkippedDatasets.includes(shortName)
+        ) {
+          const snapshot = {
+            spatialBounds: { ...constraints.spatialBounds },
+            temporalRange: { ...constraints.temporalRange },
+            depthRange: { ...constraints.depthRange },
+            temporalEnabled: constraints.temporalEnabled,
+            depthEnabled: constraints.depthEnabled,
+            includePartialOverlaps: constraints.includePartialOverlaps,
+            timestamp: new Date(),
+          };
+          backendSnapshots[shortName] = snapshot;
+          log.debug('recalculation snapshot captured', { shortName, snapshot });
+        }
+      });
+
+      // Remove backend-recalculated datasets from estimatedRowCounts Set
+      // (They were recalculated via backend, not estimated)
+      const updatedEstimatedSet = new Set(get().estimatedRowCounts);
+      Object.keys(data.results).forEach((shortName) => {
+        updatedEstimatedSet.delete(shortName);
+      });
+
+      // State update with backend row counts only (estimated results already applied in Phase 1)
+      set({
+        calculatedRowCounts: { ...get().calculatedRowCounts, ...data.results },
+        datasetConstraintSnapshots: backendSnapshots,
+        estimatedRowCounts: updatedEstimatedSet,
+        skippedDatasets: allSkippedDatasets,
+        failedRowCounts: data.failed,
+        rowCountsLoading: false,
+        rowCountLoadingDatasets: new Set(),
+      });
+    } catch (error) {
+      set({
+        rowCountsLoading: false,
+        rowCountLoadingDatasets: new Set(),
+        rowCountError: error.message || 'Failed to calculate row counts',
+      });
+    }
+  },
+
+  /**
+   * Calculate row counts for stale datasets only.
+   * This is the "Recalculate All" action triggered from the table header button.
+   * Sets hasUsedGlobalRecalculation flag to true.
+   *
+   * @param {Array<Object>} results - Array of dataset objects with type and shortName
+   * @param {Object} constraints - Current constraint configuration (from buildConstraintsFromStore)
+   * @returns {Promise<void>}
+   */
+  calculateRowCountsForStale: async (results, constraints) => {
+    // Can't calculate if no results
+    if (!results || results.length === 0) {
+      return;
+    }
+
+    // Filter to only include stale datasets
+    const staleDatasets = results.filter((dataset) => {
+      const { isStale } = get().isDatasetStale(
+        dataset.shortName,
+        constraints,
+        dataset.datasetUtilization,
+        dataset.type,
+      );
+      return isStale;
+    });
+
+    // Delegate to calculateRowCountsForDatasets (per-dataset snapshots stored automatically)
+    await get().calculateRowCountsForDatasets(staleDatasets, constraints);
+
+    // Set global recalculation flag (consumed opportunity for "Recalculate All" button)
+    set({ hasUsedGlobalRecalculation: true });
+  },
+
+  /**
+   * Clear row count calculation results.
+   * Called when a new search is performed.
+   */
+  clearRowCounts: () => {
+    set({
+      calculatedRowCounts: {},
+      rowCountError: null,
+      skippedDatasets: [],
+      failedRowCounts: [],
+      estimatedRowCounts: new Set(),
+      rowCountLoadingDatasets: new Set(),
+      datasetConstraintSnapshots: {},
+      hasUsedGlobalRecalculation: false, // Reset for new search
+    });
+  },
+
+  /**
+   * Reset only the global recalculation flag without clearing calculated row counts.
+   * Called when a new search is performed to make "Recalculate All" button reappear
+   * while preserving existing calculated row count values.
+   */
+  resetGlobalRecalculation: () => {
+    set({ hasUsedGlobalRecalculation: false });
+  },
+
+  /**
+   * Store dataset IDs from the last successful search.
+   * Used to detect when datasets are no longer in search results for staleness detection.
+   *
+   * @param {Array<string>} datasetIds - Array of dataset short names from search results
+   */
+  setLastSearchDatasetIds: (datasetIds) => {
+    set({ lastSearchDatasetIds: new Set(datasetIds) });
+  },
+}));
+
+export default useRowCountCalculationStore;

--- a/src/features/collections/addDatasets/SpatialTemporalTab/store/spatialTemporalSearchStore.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/store/spatialTemporalSearchStore.js
@@ -5,6 +5,13 @@ import {
   createSearchQuery,
 } from '../../../../catalogSearch/api';
 import { transformSpatialTemporalResults } from '../utils/spatialTemporalTransformer';
+import useRowCountCalculationStore from './rowCountCalculationStore';
+import {
+  isValidSpatialBounds,
+  isValidTemporalRange,
+  isValidDepthRange,
+} from '../utils/validation';
+import { areConstraintsEqual } from '../utils/constraintComparison';
 
 /**
  * Zustand store managing spatial-temporal overlap search state and actions.
@@ -98,6 +105,13 @@ const useSpatialTemporalSearchStore = create((set, get) => ({
   results: null, // null = no search performed yet, [] = search returned 0 results
   isSearching: false,
   searchError: null,
+
+  /**
+   * Snapshot of constraints from last successful search
+   * Used to prevent redundant searches with identical constraints
+   * @type {Object | null}
+   */
+  lastSearchConstraints: null,
 
   /**
    * UI state: Constraints section expansion
@@ -288,8 +302,13 @@ const useSpatialTemporalSearchStore = create((set, get) => ({
       return;
     }
 
-    // Start search
-    set({ isSearching: true, searchError: null });
+    // Start search - reset global recalculation flag to show "Recalculate All" button again
+    // but preserve calculated row counts (they will be marked stale if needed)
+    useRowCountCalculationStore.getState().resetGlobalRecalculation();
+    set({
+      isSearching: true,
+      searchError: null,
+    });
 
     try {
       // Build query
@@ -331,6 +350,22 @@ const useSpatialTemporalSearchStore = create((set, get) => ({
         depth: depthEnabled ? depthRange : null,
       });
 
+      // Store constraint snapshot on successful search
+      const lastSearchConstraints = {
+        spatialBounds: { ...spatialBounds },
+        temporalEnabled,
+        temporalRange: { ...temporalRange },
+        depthEnabled,
+        depthRange: { ...depthRange },
+        includePartialOverlaps,
+      };
+
+      // Track search result dataset IDs for staleness detection
+      const datasetIds = enhancedResults.map((dataset) => dataset.shortName);
+      useRowCountCalculationStore
+        .getState()
+        .setLastSearchDatasetIds(datasetIds);
+
       // Auto-collapse constraints after search completes (if user hasn't manually toggled)
       const { userHasManuallyToggled, isConstraintsExpanded } = get();
       const shouldAutoCollapse =
@@ -341,6 +376,7 @@ const useSpatialTemporalSearchStore = create((set, get) => ({
       set({
         results: enhancedResults,
         isSearching: false,
+        lastSearchConstraints,
         ...(shouldAutoCollapse && { isConstraintsExpanded: false }),
       });
     } catch (error) {
@@ -353,10 +389,11 @@ const useSpatialTemporalSearchStore = create((set, get) => ({
 
   /**
    * Clear search results and error state.
+   * Also clears last search constraints to allow re-searching.
    */
   clearResults: () => {
     // TODO: Implement in T024
-    set({ results: null, searchError: null });
+    set({ results: null, searchError: null, lastSearchConstraints: null });
   },
 
   /**
@@ -414,47 +451,8 @@ const useSpatialTemporalSearchStore = create((set, get) => ({
    * @returns {boolean} True if spatial bounds are valid
    */
   hasValidSpatialBounds: () => {
-    // TODO: Implement in T025
     const { spatialBounds } = get();
-
-    // All fields must be present
-    if (
-      spatialBounds.latMin === null ||
-      spatialBounds.latMax === null ||
-      spatialBounds.lonMin === null ||
-      spatialBounds.lonMax === null
-    ) {
-      return false;
-    }
-
-    // Latitude validation
-    if (
-      spatialBounds.latMin < -90 ||
-      spatialBounds.latMin > 90 ||
-      spatialBounds.latMax < -90 ||
-      spatialBounds.latMax > 90
-    ) {
-      return false;
-    }
-
-    // North > South
-    if (spatialBounds.latMin >= spatialBounds.latMax) {
-      return false;
-    }
-
-    // Longitude validation
-    if (
-      spatialBounds.lonMin < -180 ||
-      spatialBounds.lonMin > 180 ||
-      spatialBounds.lonMax < -180 ||
-      spatialBounds.lonMax > 180
-    ) {
-      return false;
-    }
-
-    // Longitude can wrap (lonMin > lonMax is valid for date line crossing)
-
-    return true;
+    return isValidSpatialBounds(spatialBounds);
   },
 
   /**
@@ -463,44 +461,58 @@ const useSpatialTemporalSearchStore = create((set, get) => ({
    * @returns {boolean} True if search can be executed
    */
   canSearch: () => {
-    // TODO: Implement in T025
     const {
       isInitialized,
       isSearching,
+      spatialBounds,
       temporalEnabled,
       temporalRange,
       depthEnabled,
       depthRange,
-      hasValidSpatialBounds,
+      includePartialOverlaps,
+      lastSearchConstraints,
     } = get();
 
-    // Must be initialized and not currently searching
     if (!isInitialized || isSearching) {
       return false;
     }
 
-    // Spatial bounds must be valid
-    if (!hasValidSpatialBounds()) {
+    if (!isValidSpatialBounds(spatialBounds)) {
       return false;
     }
 
-    // If temporal enabled, range must be valid
     if (temporalEnabled) {
-      if (!temporalRange.timeMin || !temporalRange.timeMax) {
-        return false;
-      }
-      if (temporalRange.timeMin > temporalRange.timeMax) {
+      const temporalConstraints = { enabled: true, ...temporalRange };
+      if (!isValidTemporalRange(temporalConstraints)) {
         return false;
       }
     }
 
-    // If depth enabled, range must be valid
     if (depthEnabled) {
-      if (depthRange.depthMin === null || depthRange.depthMax === null) {
+      const depthConstraints = { enabled: true, ...depthRange };
+      if (!isValidDepthRange(depthConstraints)) {
         return false;
       }
-      if (depthRange.depthMin > depthRange.depthMax) {
-        return false;
+    }
+
+    // Prevent redundant searches: check if current constraints match last search
+    if (lastSearchConstraints) {
+      const currentConstraints = {
+        spatialBounds,
+        temporalEnabled,
+        temporalRange,
+        depthEnabled,
+        depthRange,
+        includePartialOverlaps,
+      };
+
+      const constraintsMatch = areConstraintsEqual(
+        currentConstraints,
+        lastSearchConstraints,
+      );
+
+      if (constraintsMatch) {
+        return false; // Can't search with same constraints as last search
       }
     }
 

--- a/src/features/collections/addDatasets/SpatialTemporalTab/utils/columnDefinitions.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/utils/columnDefinitions.js
@@ -1,0 +1,251 @@
+import React from 'react';
+import { Box, Typography } from '@material-ui/core';
+import { SortableHeader } from '../../../../../shared/sorting';
+import {
+  DatasetNameLink,
+  ROW_STATES,
+  InfoTooltip,
+} from '../../../../../shared/components';
+import DataTypeFilterDropdown from '../components/DataTypeFilterDropdown';
+import {
+  renderDatasetUtilization,
+  renderSpatialCoverage,
+  renderTemporalCoverage,
+  renderDepthCoverage,
+  renderTemporalUtilization,
+  renderDepthUtilization,
+  renderDateOverlap,
+  renderSpatialOverlap,
+  renderDepthOverlap,
+} from './columnRenderers';
+
+export function createColumnDefinitions(deps) {
+  const {
+    classes,
+    getStatusIcon,
+    currentCollectionDatasetIds,
+    sortMode,
+    sortDirection,
+    onSortChange,
+    selectedDataTypes,
+    setSelectedDataTypes,
+    resultsCount,
+  } = deps;
+
+  return {
+    status: {
+      header: 'Status',
+      cellClass: classes.statusCell,
+      align: 'center',
+      render: (dataset) => {
+        const isAlreadyPresent = currentCollectionDatasetIds.has(
+          dataset.shortName,
+        );
+        return getStatusIcon(
+          isAlreadyPresent ? ROW_STATES.ALREADY_PRESENT : ROW_STATES.NORMAL,
+        );
+      },
+    },
+
+    name: {
+      header: 'Dataset Name',
+      cellClass: classes.datasetNameCell,
+      render: (dataset) => (
+        <Box>
+          <DatasetNameLink
+            datasetShortName={dataset.shortName}
+            typographyProps={{
+              variant: 'body2',
+              noWrap: true,
+            }}
+          />
+          {dataset.longName && (
+            <Typography className={classes.datasetDescription}>
+              {dataset.longName}
+            </Typography>
+          )}
+        </Box>
+      ),
+    },
+
+    type: {
+      header: (
+        <Box display="flex" alignItems="center">
+          Type
+          <DataTypeFilterDropdown
+            selectedTypes={selectedDataTypes}
+            onSelectionChange={setSelectedDataTypes}
+            disabled={resultsCount === 0}
+          />
+        </Box>
+      ),
+      cellClass: classes.typeCell,
+      render: (dataset) => dataset.type || 'N/A',
+    },
+
+    datasetUtilization: {
+      header: (
+        <SortableHeader
+          field="datasetUtilization"
+          label={
+            <Box
+              component="span"
+              display="inline-flex"
+              alignItems="flex-start"
+              gap={0.375}
+            >
+              <span>Dataset Coverage</span>
+              <InfoTooltip
+                title="How much of this dataset's extent is within the ROI? 100% means the entire dataset extent falls within your ROI."
+                fontSize="small"
+              />
+            </Box>
+          }
+          isActive={sortMode === 'utilization'}
+          direction={sortMode === 'utilization' ? sortDirection : 'desc'}
+          uiPattern="headers-only"
+          onClick={onSortChange}
+          className={classes.clickableHeader}
+        />
+      ),
+      cellClass: classes.utilizationCell,
+      align: 'right',
+      render: renderDatasetUtilization,
+    },
+
+    spatialCoverage: {
+      header: (
+        <SortableHeader
+          field="spatialCoverage"
+          label={
+            <Box
+              component="span"
+              display="inline-flex"
+              alignItems="flex-start"
+              gap={0.375}
+            >
+              <span>ROI Coverage</span>
+              <InfoTooltip
+                title="How much of the ROI does this dataset's extent cover? 100% means the dataset extent covers your entire ROI."
+                fontSize="small"
+              />
+            </Box>
+          }
+          isActive={sortMode === 'spatial'}
+          direction={sortMode === 'spatial' ? sortDirection : 'desc'}
+          uiPattern="headers-only"
+          onClick={onSortChange}
+          className={classes.clickableHeader}
+        />
+      ),
+      cellClass: classes.coverageCell,
+      align: 'right',
+      render: renderSpatialCoverage,
+    },
+
+    temporalCoverage: {
+      header: (
+        <SortableHeader
+          field="temporalCoverage"
+          label="Temporal Coverage"
+          isActive={sortMode === 'temporal'}
+          direction={sortMode === 'temporal' ? sortDirection : 'desc'}
+          uiPattern="headers-only"
+          onClick={onSortChange}
+          className={classes.clickableHeader}
+        />
+      ),
+      cellClass: classes.coverageCell,
+      align: 'right',
+      render: renderTemporalCoverage,
+    },
+
+    depthCoverage: {
+      header: (
+        <SortableHeader
+          field="depthCoverage"
+          label="Depth Coverage"
+          isActive={sortMode === 'depth'}
+          direction={sortMode === 'depth' ? sortDirection : 'desc'}
+          uiPattern="headers-only"
+          onClick={onSortChange}
+          className={classes.clickableHeader}
+        />
+      ),
+      cellClass: classes.coverageCell,
+      align: 'right',
+      render: renderDepthCoverage,
+    },
+
+    temporalUtilization: {
+      header: (
+        <Box
+          component="span"
+          display="inline-flex"
+          alignItems="flex-start"
+          gap={0.375}
+        >
+          <span>Temporal Util</span>
+          <InfoTooltip
+            title="Percentage of dataset's temporal extent within your search range"
+            fontSize="small"
+          />
+        </Box>
+      ),
+      cellClass: classes.coverageCell,
+      align: 'right',
+      render: renderTemporalUtilization,
+    },
+
+    depthUtilization: {
+      header: (
+        <Box
+          component="span"
+          display="inline-flex"
+          alignItems="flex-start"
+          gap={0.375}
+        >
+          <span>Depth Util</span>
+          <InfoTooltip
+            title="Percentage of dataset's depth extent within your search range"
+            fontSize="small"
+          />
+        </Box>
+      ),
+      cellClass: classes.coverageCell,
+      align: 'right',
+      render: renderDepthUtilization,
+    },
+
+    dateOverlap: {
+      header: 'Date Overlap',
+      cellClass: classes.overlapCell,
+      render: renderDateOverlap,
+    },
+
+    spatialOverlap: {
+      header: (
+        <Box
+          component="span"
+          display="inline-flex"
+          alignItems="flex-start"
+          gap={0.375}
+        >
+          <span>Spatial Overlap</span>
+          <InfoTooltip
+            title="The geographic bounds of the overlapping region between this dataset and your ROI."
+            fontSize="small"
+          />
+        </Box>
+      ),
+      cellClass: classes.overlapCell,
+      render: renderSpatialOverlap,
+    },
+
+    depthOverlap: {
+      header: 'Depth Overlap',
+      cellClass: classes.overlapCell,
+      render: renderDepthOverlap,
+    },
+  };
+}

--- a/src/features/collections/addDatasets/SpatialTemporalTab/utils/columnRenderers.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/utils/columnRenderers.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { formatCoveragePercent } from './percentageFormatter';
+
+export function renderDatasetUtilization(dataset) {
+  if (typeof dataset.datasetUtilization === 'number') {
+    const percent = dataset.datasetUtilization * 100;
+    const rounded = parseFloat(percent.toFixed(1));
+    if (rounded === 0 && dataset.datasetUtilization > 0) {
+      return '< 0.05%';
+    }
+    return `${rounded.toFixed(1)}%`;
+  }
+  return 'N/A';
+}
+
+export function renderSpatialCoverage(dataset) {
+  return typeof dataset.overlap.spatial.coveragePercent === 'number'
+    ? `${Math.round(dataset.overlap.spatial.coveragePercent * 100)}%`
+    : dataset.overlap.spatial.coveragePercent;
+}
+
+export function renderTemporalCoverage(dataset) {
+  if (dataset.overlap.temporal) {
+    return typeof dataset.overlap.temporal.coveragePercent === 'number'
+      ? `${Math.round(dataset.overlap.temporal.coveragePercent * 100)}%`
+      : dataset.overlap.temporal.coveragePercent;
+  }
+  return 'N/A';
+}
+
+export function renderDepthCoverage(dataset) {
+  if (dataset.overlap.depth) {
+    return typeof dataset.overlap.depth.coveragePercent === 'number'
+      ? `${Math.round(dataset.overlap.depth.coveragePercent * 100)}%`
+      : dataset.overlap.depth.coveragePercent;
+  }
+  return 'N/A';
+}
+
+export function renderTemporalUtilization(dataset) {
+  if (
+    dataset.overlap.temporal &&
+    dataset.overlap.temporal.utilization !== undefined
+  ) {
+    return `${Math.round(dataset.overlap.temporal.utilization * 100)}%`;
+  }
+  return 'N/A';
+}
+
+export function renderDepthUtilization(dataset) {
+  if (dataset.overlap.depth && dataset.overlap.depth.utilization !== null) {
+    return `${Math.round(dataset.overlap.depth.utilization * 100)}%`;
+  }
+  return 'N/A';
+}
+
+export function renderDateOverlap(dataset) {
+  return dataset.overlap.temporal ? dataset.overlap.temporal.range : 'N/A';
+}
+
+export function renderSpatialOverlap(dataset) {
+  return dataset.overlap.spatial.extent
+    .split('\n')
+    .map((line, index, array) => (
+      <React.Fragment key={index}>
+        {line}
+        {index < array.length - 1 && <br />}
+      </React.Fragment>
+    ));
+}
+
+export function renderDepthOverlap(dataset) {
+  return dataset.overlap.depth ? dataset.overlap.depth.range : 'N/A';
+}

--- a/src/features/collections/addDatasets/SpatialTemporalTab/utils/constraintComparison.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/utils/constraintComparison.js
@@ -1,0 +1,112 @@
+/**
+ * Constraint Comparison Utility
+ *
+ * Provides deep equality checking for spatial-temporal constraint configurations.
+ * Used to detect changes between current constraints and recalculation snapshots.
+ */
+
+/**
+ * Performs deep equality check between current constraint configuration
+ * and recalculation snapshot to detect changes that invalidate cached row counts.
+ *
+ * Comparison rules:
+ * - Spatial bounds: Always compared (latMin, latMax, lonMin, lonMax)
+ * - Boolean flags: Always compared (temporalEnabled, depthEnabled, includePartialOverlaps)
+ * - Temporal range: Only compared when temporalEnabled is true in BOTH configurations
+ * - Depth range: Only compared when depthEnabled is true in BOTH configurations
+ * - Date objects: Compared by value using .getTime(), not by reference
+ *
+ * @param {Object} current - Current constraint configuration
+ * @param {Object} current.spatialBounds - Current spatial bounds
+ * @param {number} current.spatialBounds.latMin - Minimum latitude (-90 to 90)
+ * @param {number} current.spatialBounds.latMax - Maximum latitude (-90 to 90)
+ * @param {number} current.spatialBounds.lonMin - Minimum longitude (-180 to 180)
+ * @param {number} current.spatialBounds.lonMax - Maximum longitude (-180 to 180)
+ * @param {Object} current.temporalRange - Current temporal range
+ * @param {Date|null} current.temporalRange.timeMin - Start date of temporal constraint
+ * @param {Date|null} current.temporalRange.timeMax - End date of temporal constraint
+ * @param {Object} current.depthRange - Current depth range
+ * @param {number|null} current.depthRange.depthMin - Minimum depth in meters
+ * @param {number|null} current.depthRange.depthMax - Maximum depth in meters
+ * @param {boolean} current.temporalEnabled - Whether temporal constraints are active
+ * @param {boolean} current.depthEnabled - Whether depth constraints are active
+ * @param {boolean} current.includePartialOverlaps - Whether partial overlap mode is enabled
+ *
+ * @param {Object} snapshot - Recalculation snapshot configuration (same structure as current)
+ *
+ * @returns {boolean} - true if constraints are equal, false if different
+ *
+ * @example
+ * const current = {
+ *   spatialBounds: { latMin: 30, latMax: 35, lonMin: -65, lonMax: -60 },
+ *   temporalRange: { timeMin: new Date('2020-01-01'), timeMax: new Date('2023-12-31') },
+ *   depthRange: { depthMin: 0, depthMax: 100 },
+ *   temporalEnabled: true,
+ *   depthEnabled: true,
+ *   includePartialOverlaps: false,
+ * };
+ *
+ * const snapshot = {
+ *   spatialBounds: { latMin: 30, latMax: 35, lonMin: -65, lonMax: -60 },
+ *   temporalRange: { timeMin: new Date('2020-01-01'), timeMax: new Date('2023-12-31') },
+ *   depthRange: { depthMin: 0, depthMax: 100 },
+ *   temporalEnabled: true,
+ *   depthEnabled: true,
+ *   includePartialOverlaps: false,
+ * };
+ *
+ * areConstraintsEqual(current, snapshot); // returns true
+ */
+export const areConstraintsEqual = (current, snapshot) => {
+  // Step 1: Compare boolean flags (enabled states and overlap mode)
+  if (current.temporalEnabled !== snapshot.temporalEnabled) {
+    return false;
+  }
+
+  if (current.depthEnabled !== snapshot.depthEnabled) {
+    return false;
+  }
+
+  if (current.includePartialOverlaps !== snapshot.includePartialOverlaps) {
+    return false;
+  }
+
+  // Step 2: Compare spatial bounds (all 4 values)
+  if (
+    current.spatialBounds.latMin !== snapshot.spatialBounds.latMin ||
+    current.spatialBounds.latMax !== snapshot.spatialBounds.latMax ||
+    current.spatialBounds.lonMin !== snapshot.spatialBounds.lonMin ||
+    current.spatialBounds.lonMax !== snapshot.spatialBounds.lonMax
+  ) {
+    return false;
+  }
+
+  // Step 3: Compare temporal range (only if enabled in BOTH)
+  if (current.temporalEnabled && snapshot.temporalEnabled) {
+    // Compare Date objects by value using .getTime()
+    const currentTimeMin = current.temporalRange.timeMin?.getTime();
+    const snapshotTimeMin = snapshot.temporalRange.timeMin?.getTime();
+    const currentTimeMax = current.temporalRange.timeMax?.getTime();
+    const snapshotTimeMax = snapshot.temporalRange.timeMax?.getTime();
+
+    if (
+      currentTimeMin !== snapshotTimeMin ||
+      currentTimeMax !== snapshotTimeMax
+    ) {
+      return false;
+    }
+  }
+
+  // Step 4: Compare depth range (only if enabled in BOTH)
+  if (current.depthEnabled && snapshot.depthEnabled) {
+    if (
+      current.depthRange.depthMin !== snapshot.depthRange.depthMin ||
+      current.depthRange.depthMax !== snapshot.depthRange.depthMax
+    ) {
+      return false;
+    }
+  }
+
+  // Step 5: All comparisons passed - constraints are equal
+  return true;
+};

--- a/src/features/collections/addDatasets/SpatialTemporalTab/utils/percentageFormatter.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/utils/percentageFormatter.js
@@ -1,0 +1,17 @@
+/**
+ * Format coverage percentage with edge case handling
+ * @param {number} value - Decimal value (0-1) or percentage (0-100)
+ * @returns {string} Formatted percentage or N/A
+ */
+export function formatCoveragePercent(value) {
+  if (typeof value !== 'number') return 'N/A';
+
+  const percent = value <= 1 ? value * 100 : value;
+  const rounded = parseFloat(percent.toFixed(1));
+
+  if (rounded === 0 && value > 0) {
+    return '< 0.05%';
+  }
+
+  return `${rounded.toFixed(1)}%`;
+}

--- a/src/features/collections/addDatasets/SpatialTemporalTab/utils/spatialTemporalTransformer.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/utils/spatialTemporalTransformer.js
@@ -375,6 +375,7 @@ export function transformSpatialTemporalResult(rawDataset, userConstraints) {
       overlap.temporal = {
         coveragePercent: temporalCoveragePercent,
         range: temporalRange,
+        utilization: rawDataset.temporal_utilization || 0, // NEW - for future use
       };
     } catch (error) {
       // Graceful degradation: log error but provide default values
@@ -407,6 +408,10 @@ export function transformSpatialTemporalResult(rawDataset, userConstraints) {
       overlap.depth = {
         coveragePercent: depthCoveragePercent,
         range: depthRange,
+        utilization:
+          rawDataset.depth_utilization !== null
+            ? rawDataset.depth_utilization
+            : null, // NEW - for future use
       };
     } catch (error) {
       // Graceful degradation: log error but provide default values

--- a/src/features/collections/addDatasets/SpatialTemporalTab/utils/validation.js
+++ b/src/features/collections/addDatasets/SpatialTemporalTab/utils/validation.js
@@ -306,3 +306,30 @@ export function validateDepthRange(constraints) {
     errors,
   };
 }
+
+/**
+ * Check if spatial bounds are valid (boolean only)
+ * @param {BoundingBox} bounds - Spatial bounds to validate
+ * @returns {boolean} True if valid
+ */
+export function isValidSpatialBounds(bounds) {
+  return validateSpatialBounds(bounds).valid;
+}
+
+/**
+ * Check if temporal constraints are valid (boolean only)
+ * @param {TemporalConstraints} constraints - Temporal constraints to validate
+ * @returns {boolean} True if valid
+ */
+export function isValidTemporalRange(constraints) {
+  return validateTemporalRange(constraints).valid;
+}
+
+/**
+ * Check if depth constraints are valid (boolean only)
+ * @param {DepthConstraints} constraints - Depth constraints to validate
+ * @returns {boolean} True if valid
+ */
+export function isValidDepthRange(constraints) {
+  return validateDepthRange(constraints).valid;
+}

--- a/src/features/collections/addDatasets/components/CollectionSearchSection.js
+++ b/src/features/collections/addDatasets/components/CollectionSearchSection.js
@@ -33,27 +33,27 @@ const useStyles = makeStyles((theme) => ({
     wordWrap: 'break-word',
     lineHeight: 1.4,
   },
-  groupHeaderPrivate: {
+  groupHeaderMy: {
     gridColumn: '1 / -1', // Span all columns
     display: 'flex',
     alignItems: 'center',
     width: '100%',
     padding: theme.spacing(1, 2),
-    backgroundColor: '#ffcdd2 !important',
-    color: '#c62828',
+    backgroundColor: '#ffe0b2 !important',
+    color: '#e65100',
     fontWeight: 500,
     fontSize: '0.875rem',
     pointerEvents: 'none',
     cursor: 'default',
   },
-  groupHeaderPublic: {
+  groupHeaderOther: {
     gridColumn: '1 / -1', // Span all columns
     display: 'flex',
     alignItems: 'center',
     width: '100%',
     padding: theme.spacing(1, 2),
-    backgroundColor: '#c8e6c9 !important',
-    color: '#2e7d32',
+    backgroundColor: '#bbdefb !important',
+    color: '#1565c0',
     fontWeight: 500,
     fontSize: '0.875rem',
     pointerEvents: 'none',
@@ -160,10 +160,21 @@ const CollectionSearchSection = ({
               position: 'sticky',
               top: 0,
               zIndex: 3,
-              paddingRight: '16px', // Extra padding for scrollbar space
             }}
           >
             Total Datasets
+          </div>
+          <div
+            className={classes.headerCell}
+            style={{
+              justifyContent: 'center',
+              position: 'sticky',
+              top: 0,
+              zIndex: 3,
+              paddingRight: '16px', // Extra padding for scrollbar space
+            }}
+          >
+            Visibility
           </div>
         </>
       );
@@ -171,11 +182,11 @@ const CollectionSearchSection = ({
 
     // Render group header
     if (option.isGroupHeader) {
-      const isPrivate = option.label === 'Private Collections';
+      const isMyCollections = option.label === 'My Collections';
       return (
         <div
           className={
-            isPrivate ? classes.groupHeaderPrivate : classes.groupHeaderPublic
+            isMyCollections ? classes.groupHeaderMy : classes.groupHeaderOther
           }
         >
           <span>{option.label}</span>
@@ -194,9 +205,15 @@ const CollectionSearchSection = ({
         </div>
         <div
           className={`${classes.dataCell} ${classes.datasetCount}`}
-          style={{ justifyContent: 'flex-end', paddingRight: '16px' }}
+          style={{ justifyContent: 'flex-end' }}
         >
           {option.datasetCount}
+        </div>
+        <div
+          className={classes.dataCell}
+          style={{ justifyContent: 'center', paddingRight: '16px' }}
+        >
+          <CollectionStatusBadge isPublic={option.isPublic} />
         </div>
       </>
     );
@@ -207,37 +224,45 @@ const CollectionSearchSection = ({
     return [{ isHeader: true, id: 'header' }];
   }, []);
 
-  // Process function to insert group headers between private and public collections
+  // Process function to insert group headers between my collections and other public collections
   const processItems = React.useCallback((items) => {
     const processedItems = [];
 
-    // Separate, sort, and add private collections
-    const privateItems = items
-      .filter((item) => !item.isPublic)
+    // Separate my collections (owned by current user)
+    // Sort by visibility (private first, then public) and then alphabetically within each group
+    const myCollections = items
+      .filter((item) => item.isOwner)
+      .sort((a, b) => {
+        // First sort by visibility: private (false) before public (true)
+        if (a.isPublic !== b.isPublic) {
+          return a.isPublic ? 1 : -1;
+        }
+        // Then sort alphabetically by name
+        return a.name.localeCompare(b.name);
+      });
+
+    const otherPublicCollections = items
+      .filter((item) => !item.isOwner)
       .sort((a, b) => a.name.localeCompare(b.name));
 
-    const publicItems = items
-      .filter((item) => item.isPublic)
-      .sort((a, b) => a.name.localeCompare(b.name));
-
-    // Add private section with header
-    if (privateItems.length > 0) {
+    // Add my collections section with header
+    if (myCollections.length > 0) {
       processedItems.push({
         isGroupHeader: true,
-        label: 'Private Collections',
-        id: 'private-header',
+        label: 'My Collections',
+        id: 'my-collections-header',
       });
-      processedItems.push(...privateItems);
+      processedItems.push(...myCollections);
     }
 
-    // Add public section with header
-    if (publicItems.length > 0) {
+    // Add other public collections section with header
+    if (otherPublicCollections.length > 0) {
       processedItems.push({
         isGroupHeader: true,
-        label: 'Public Collections',
-        id: 'public-header',
+        label: 'Other Public Collections',
+        id: 'other-public-header',
       });
-      processedItems.push(...publicItems);
+      processedItems.push(...otherPublicCollections);
     }
 
     return processedItems;
@@ -261,7 +286,7 @@ const CollectionSearchSection = ({
         disablePortal={true}
         prependOptions={prependOptions}
         processItems={processItems}
-        listboxGridColumns="minmax(150px, 1.5fr) minmax(200px, 2.5fr) minmax(100px, 0.5fr)"
+        listboxGridColumns="minmax(150px, 1.5fr) minmax(200px, 2fr) minmax(80px, 0.5fr) minmax(100px, 0.75fr)"
       />
     </Box>
   );

--- a/src/features/collections/addDatasets/components/CollectionSummaryCard.js
+++ b/src/features/collections/addDatasets/components/CollectionSummaryCard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Typography, CircularProgress } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import CollectionStatistics from '../../components/CollectionStatistics';
 import CollectionStatusBadge from '../../components/CollectionStatusBadge';
 
 const useStyles = makeStyles((theme) => ({
@@ -104,38 +103,6 @@ const CollectionSummaryCard = ({ summary, isLoading, loadError }) => {
     }
   };
 
-  // Prepare statistics for CollectionStatistics component
-  // Always show: Total Datasets, Valid Datasets
-  // Conditionally show: Already in Collection (if > 0), Invalid Datasets (if > 0, shown last)
-  const stats = [
-    {
-      value: totalDatasets || 0,
-      label: 'Total Datasets',
-    },
-    {
-      value: validDatasets || 0,
-      label: 'Valid Datasets',
-    },
-  ];
-
-  // Add "Already in Collection" if there are any (with gray border)
-  if (alreadyInCollection > 0) {
-    stats.push({
-      value: alreadyInCollection,
-      label: 'Already in Collection',
-      borderColor: 'rgba(128, 128, 128, 0.6)',
-    });
-  }
-
-  // Add "Invalid Datasets" last, only if there are any (with yellow border)
-  if (invalidDatasets > 0) {
-    stats.push({
-      value: invalidDatasets,
-      label: 'Invalid Datasets',
-      borderColor: 'rgba(255, 193, 7, 0.6)',
-    });
-  }
-
   if (isLoading) {
     return (
       <Box className={classes.card}>
@@ -178,9 +145,6 @@ const CollectionSummaryCard = ({ summary, isLoading, loadError }) => {
           <Typography className={classes.description}>{description}</Typography>
         </Box>
       )}
-
-      {/* Statistics */}
-      <CollectionStatistics compact stats={stats} itemsPerRow={stats.length} />
     </Box>
   );
 };

--- a/src/features/collections/api/collectionsApi.js
+++ b/src/features/collections/api/collectionsApi.js
@@ -381,4 +381,55 @@ collectionsAPI.downloadDatasets = async (datasetShortNames, collectionId) => {
   DownloadService.downloadBlob(blob, filename);
 };
 
+/**
+ * Calculate row counts for datasets based on search constraints
+ * @param {string[]} shortNames - Array of dataset short names
+ * @param {Object} constraints - Search constraints object
+ * @param {Object} constraints.spatial - Spatial bounds (latMin, latMax, lonMin, lonMax)
+ * @param {Object} [constraints.temporal] - Optional temporal range (min, max as ISO date strings)
+ * @param {Object} [constraints.depth] - Optional depth range (min, max)
+ * @returns {Promise<Response>} Response with calculated row counts, skipped datasets, and failed datasets
+ * @throws {Error} 400: Validation errors, 500: Server error
+ * @description Calculates actual row counts for datasets based on search constraints.
+ * Automatically excludes cluster-only datasets (only available on cluster server, too large for constrained queries).
+ *
+ * Returns:
+ * - results: Object mapping shortName to row count for successfully calculated datasets
+ * - skipped: Array of dataset shortNames that were skipped (cluster-only datasets)
+ * - failed: Array of dataset shortNames that failed calculation
+ * - metadata: Summary statistics (totalCalculated, totalSkipped, totalFailed)
+ *
+ * NOTE: This endpoint does NOT require authentication.
+ *
+ * @example
+ * const result = await collectionsAPI.calculateRowCounts(
+ *   ['dataset1', 'dataset2', 'cluster_dataset'],
+ *   {
+ *     spatial: { latMin: 30, latMax: 40, lonMin: -120, lonMax: -110 },
+ *     temporal: { min: '2020-01-01', max: '2020-12-31' },
+ *     depth: { min: 0, max: 100 }
+ *   }
+ * );
+ *
+ * // Response:
+ * // {
+ * //   results: { dataset1: 12345, dataset2: 67890 },
+ * //   skipped: ['cluster_dataset'],
+ * //   failed: ['problem_dataset'],
+ * //   metadata: { totalCalculated: 2, totalSkipped: 1, totalFailed: 1 }
+ * // }
+ */
+collectionsAPI.calculateRowCounts = async (shortNames, constraints) => {
+  const endpoint = `${apiUrl}/api/collections/calculate-row-counts`;
+
+  return await fetch(endpoint, {
+    ...postOptions,
+    method: 'POST',
+    body: JSON.stringify({
+      shortNames,
+      constraints,
+    }),
+  });
+};
+
 export default collectionsAPI;

--- a/src/features/collections/components/CollectionDatasetsTable.js
+++ b/src/features/collections/components/CollectionDatasetsTable.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Box,
@@ -47,10 +47,34 @@ const useStyles = makeStyles((theme) => ({
       zIndex: 2,
       padding: '8px 8px',
       border: 0,
+      verticalAlign: 'top',
+    },
+    '& .MuiTableCell-body': {
+      verticalAlign: 'top',
     },
   },
   table: {
     width: '100%',
+    // Apply first-child/last-child padding to ALL rows (header and body)
+    '& .MuiTableCell-root:first-child': {
+      paddingLeft: '16px',
+    },
+    '& .MuiTableCell-root:last-child': {
+      paddingRight: '16px',
+    },
+  },
+  tableRow: {
+    transition: 'opacity 300ms ease-out, height 300ms ease-out',
+    overflow: 'hidden',
+    '&.removing': {
+      opacity: 0,
+      height: '0px',
+      '& td': {
+        paddingTop: '0 !important',
+        paddingBottom: '0 !important',
+        borderBottom: 'none',
+      },
+    },
   },
   tableCell: {
     color: 'rgba(255, 255, 255, 0.85)',
@@ -68,6 +92,8 @@ const useStyles = makeStyles((theme) => ({
   statusCell: {
     width: '60px',
     textAlign: 'center',
+    textDecoration: 'none !important', // Prevent line-through on status in marked-for-removal rows
+    lineHeight: 1.1,
   },
   datasetNameCell: {
     minWidth: '200px',
@@ -172,6 +198,17 @@ const CollectionDatasetsTable = ({
   // Local state
   const [data, setData] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [removingDatasets, setRemovingDatasets] = useState(new Set());
+  const [rowHeights, setRowHeights] = useState({});
+
+  // Track previous dataset short names to detect additions vs removals
+  const prevShortNamesRef = useRef(null);
+
+  // Track timeout for cleanup
+  const removalTimeoutRef = useRef(null);
+
+  // Refs for measuring row heights
+  const rowRefs = useRef({});
 
   // Determine which format we received and extract short names + state map
   const shortNamesInput = datasetShortNamesWithStates || datasetShortNames;
@@ -213,9 +250,115 @@ const CollectionDatasetsTable = ({
     if (!shortNamesForFetch || shortNamesForFetch.length === 0) {
       setData([]);
       setIsLoading(false);
+      prevShortNamesRef.current = [];
       return;
     }
 
+    // Optimize for removals: detect if this is a removal-only operation
+    const prevShortNames = prevShortNamesRef.current;
+    if (prevShortNames && prevShortNames.length > 0) {
+      const currentSet = new Set(shortNamesForFetch);
+      const prevSet = new Set(prevShortNames);
+
+      // Find added and removed datasets
+      const addedDatasets = shortNamesForFetch.filter(
+        (name) => !prevSet.has(name),
+      );
+      const removedDatasets = prevShortNames.filter(
+        (name) => !currentSet.has(name),
+      );
+
+      // If only removals (no additions), filter existing data with animation
+      if (addedDatasets.length === 0 && removedDatasets.length > 0) {
+        // Clear any existing timeout
+        if (removalTimeoutRef.current) {
+          clearTimeout(removalTimeoutRef.current);
+        }
+
+        // Measure heights of rows being removed
+        const heights = {};
+        removedDatasets.forEach((shortName) => {
+          const rowElement = rowRefs.current[shortName];
+          if (rowElement) {
+            heights[shortName] = rowElement.offsetHeight;
+          }
+        });
+
+        // Set explicit heights first
+        setRowHeights(heights);
+
+        // Use requestAnimationFrame to ensure heights are applied before animation starts
+        requestAnimationFrame(() => {
+          // Mark datasets as removing to trigger animation
+          setRemovingDatasets(new Set(removedDatasets));
+
+          // Delay actual removal to allow animation to complete
+          removalTimeoutRef.current = setTimeout(() => {
+            const filteredData = data.filter((dataset) =>
+              currentSet.has(dataset.shortName),
+            );
+            setData(filteredData);
+            setRemovingDatasets(new Set());
+            setRowHeights({});
+            prevShortNamesRef.current = shortNamesForFetch;
+            removalTimeoutRef.current = null;
+
+            // Notify parent of updated data
+            if (onDataLoaded) {
+              const totalRows = filteredData.reduce((sum, dataset) => {
+                return sum + (dataset.rowCount || 0);
+              }, 0);
+              onDataLoaded(filteredData, totalRows);
+            }
+          }, 300); // Match animation duration
+        });
+
+        return;
+      }
+
+      // If mixed (both additions and removals), fetch only new datasets and merge
+      if (addedDatasets.length > 0 && removedDatasets.length > 0) {
+        const loadMixedData = async () => {
+          setIsLoading(true);
+          try {
+            // Fetch only the new datasets
+            const newPreviewData = await fetchPreviewData(
+              addedDatasets,
+              collectionId,
+            );
+
+            // Merge: filter existing data + add new data
+            const filteredExisting = data.filter((dataset) =>
+              currentSet.has(dataset.shortName),
+            );
+            const mergedData = [...filteredExisting, ...newPreviewData];
+
+            setData(mergedData);
+            prevShortNamesRef.current = shortNamesForFetch;
+
+            // Notify parent of loaded data
+            if (onDataLoaded) {
+              const totalRows = mergedData.reduce((sum, dataset) => {
+                return sum + (dataset.rowCount || 0);
+              }, 0);
+              onDataLoaded(mergedData, totalRows);
+            }
+          } catch (error) {
+            console.error('Error loading dataset data:', error);
+            if (onError) {
+              onError(error.message || 'Failed to load dataset data', 'error');
+            }
+          } finally {
+            setIsLoading(false);
+          }
+        };
+
+        loadMixedData();
+        return;
+      }
+    }
+
+    // Default behavior: fetch all datasets (for initial load or additions-only)
     const loadData = async () => {
       setIsLoading(true);
       try {
@@ -225,6 +368,7 @@ const CollectionDatasetsTable = ({
         );
 
         setData(previewData);
+        prevShortNamesRef.current = shortNamesForFetch;
 
         // Calculate total rows
         const totalRows = previewData.reduce((sum, dataset) => {
@@ -250,6 +394,9 @@ const CollectionDatasetsTable = ({
     // Cleanup
     return () => {
       clearPreviewData();
+      if (removalTimeoutRef.current) {
+        clearTimeout(removalTimeoutRef.current);
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preLoadedData, collectionId, datasetShortNamesKey]);
@@ -476,8 +623,27 @@ const CollectionDatasetsTable = ({
               // Get row class from shared hook
               const rowClass = getRowClassName(rowState);
 
+              // Check if this row is being removed (for animation)
+              const isRemoving = removingDatasets.has(dataset.shortName);
+              const removingClass = isRemoving ? 'removing' : '';
+
+              // Get explicit height if set (for smooth animation)
+              const explicitHeight = rowHeights[dataset.shortName];
+              const rowStyle = explicitHeight
+                ? { height: `${explicitHeight}px` }
+                : {};
+
               return (
-                <TableRow key={index} className={rowClass}>
+                <TableRow
+                  key={dataset.shortName}
+                  ref={(el) => {
+                    if (el) {
+                      rowRefs.current[dataset.shortName] = el;
+                    }
+                  }}
+                  className={`${classes.tableRow} ${rowClass} ${removingClass}`}
+                  style={rowStyle}
+                >
                   {/* Selection checkbox */}
                   {hasSelection && (
                     <TableCell

--- a/src/features/collections/components/CollectionFormFields.js
+++ b/src/features/collections/components/CollectionFormFields.js
@@ -81,6 +81,7 @@ const CollectionFormFields = ({
       <div className={className}>
         <TextField
           fullWidth
+          required
           label="Collection Name"
           value={name}
           onChange={onNameChange}
@@ -129,7 +130,7 @@ const CollectionFormFields = ({
                     : classes.characterCount
                 }
               >
-                {name.length}/200 characters
+                {name.trim().length}/200 characters
               </span>
             </span>
           }

--- a/src/features/collections/components/collectionFormStyles.js
+++ b/src/features/collections/components/collectionFormStyles.js
@@ -15,6 +15,9 @@ export const useCollectionFormStyles = makeStyles((theme) => ({
   fieldLabel: {
     fontSize: '1.1rem',
     fontWeight: 500,
+    '& .MuiFormLabel-asterisk': {
+      color: '#F44336',
+    },
   },
   helperTextContainer: {
     display: 'flex',
@@ -38,9 +41,11 @@ export const useCollectionFormStyles = makeStyles((theme) => ({
   },
   characterCount: {
     marginLeft: 'auto',
+    fontSize: '0.75rem',
   },
   characterCountOverLimit: {
     marginLeft: 'auto',
+    fontSize: '0.75rem',
     color: '#F44336',
   },
   descriptionField: {

--- a/src/features/collections/createModal/CreateCollectionModal.js
+++ b/src/features/collections/createModal/CreateCollectionModal.js
@@ -1,137 +1,20 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Add } from '@material-ui/icons';
-import { useDispatch } from 'react-redux';
-import useCollectionsStore from '../state/collectionsStore';
-import CollectionDialog from '../components/CollectionDialog';
-import CollectionFormFields from '../components/CollectionFormFields';
-import { useCollectionForm } from './hooks/useCollectionForm';
-import { useCollectionFormValidation } from './hooks/useCollectionFormValidation';
-import { useCreateCollectionModalStyles } from './styles/createCollectionModalStyles';
+import CreateCollectionWithDatasetsModal from '../createWithDatasets/CreateCollectionWithDatasetsModal';
 import UniversalButton from '../../../shared/components/UniversalButton';
-import { snackbarOpen } from '../../../Redux/actions/ui';
 
 const CreateCollectionModal = () => {
-  const classes = useCreateCollectionModalStyles();
-  const dispatch = useDispatch();
-  const verifyCollectionName = useCollectionsStore(
-    (state) => state.verifyCollectionName,
-  );
-  const createCollection = useCollectionsStore(
-    (state) => state.createCollection,
-  );
-
   const [open, setOpen] = useState(false);
-
-  const {
-    name,
-    description,
-    isPublic,
-    handleNameChange,
-    handleDescriptionChange,
-    handleVisibilityChange,
-    setIsPublic,
-    resetForm,
-  } = useCollectionForm();
-
-  const {
-    nameValidationState,
-    nameErrorMessage,
-    descriptionError,
-    isValid,
-    resetValidation,
-  } = useCollectionFormValidation(name, description, verifyCollectionName);
-
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submissionError, setSubmissionError] = useState('');
-
   const triggerButtonRef = useRef(null);
 
   useEffect(() => {
-    if (!open) {
+    if (!open && triggerButtonRef.current) {
       const timer = setTimeout(() => {
-        clearFormState();
-        if (triggerButtonRef.current) {
-          triggerButtonRef.current.focus();
-        }
+        triggerButtonRef.current.focus();
       }, 250);
-
       return () => clearTimeout(timer);
     }
   }, [open]);
-
-  const handleOpen = () => {
-    setOpen(true);
-  };
-
-  const clearFormState = () => {
-    resetForm();
-    resetValidation();
-    setSubmissionError('');
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-  };
-
-  const handleCancel = () => {
-    handleClose();
-  };
-
-  const handleSubmit = async () => {
-    if (!canSubmit || isSubmitting) {
-      return;
-    }
-
-    await submitCollection();
-  };
-
-  const submitCollection = async () => {
-    setIsSubmitting(true);
-    setSubmissionError('');
-
-    try {
-      const requestData = {
-        collectionName: name.trim(),
-        description: description || undefined,
-        private: !isPublic,
-        datasets: [],
-      };
-
-      await createCollection(requestData);
-
-      dispatch(
-        snackbarOpen('Collection created successfully', {
-          position: 'top',
-          severity: 'success',
-        }),
-      );
-      handleClose();
-    } catch (error) {
-      console.error('Error creating collection:', error);
-
-      let errorMessage = 'Failed to create collection. Please try again.';
-
-      if (error.message.includes('logged in')) {
-        errorMessage = 'You must be logged in to create collections';
-      } else if (error.message.includes('Network')) {
-        errorMessage = 'Network error. Please check your connection.';
-      }
-
-      dispatch(
-        snackbarOpen(errorMessage, {
-          position: 'top',
-          severity: 'error',
-        }),
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const isNameOverLimit = name.length > 200;
-  const isDescriptionOverLimit = description.length > 500;
-  const canSubmit =
-    isValid && !isSubmitting && !isNameOverLimit && !isDescriptionOverLimit;
 
   return (
     <>
@@ -139,58 +22,17 @@ const CreateCollectionModal = () => {
         ref={triggerButtonRef}
         variant="primary"
         size="large"
-        onClick={handleOpen}
+        onClick={() => setOpen(true)}
         startIcon={<Add />}
         disableRipple
       >
         CREATE NEW COLLECTION
       </UniversalButton>
 
-      <CollectionDialog
+      <CreateCollectionWithDatasetsModal
         open={open}
-        onClose={handleClose}
-        title="Create New Collection"
-        showCloseButton={true}
-        dialogClasses={classes.dialogPaper}
-        dialogRootClass={classes.dialogRoot}
-        maxWidth={false}
-        disableScrollLock={true}
-        ariaLabelledBy="create-collection-dialog-title"
-        actions={
-          <>
-            <UniversalButton
-              onClick={handleCancel}
-              variant="default"
-              size="large"
-            >
-              CANCEL
-            </UniversalButton>
-            <UniversalButton
-              onClick={handleSubmit}
-              variant="primary"
-              size="large"
-              disabled={!canSubmit}
-            >
-              {isSubmitting ? 'CREATING...' : 'CREATE COLLECTION'}
-            </UniversalButton>
-          </>
-        }
-      >
-        <CollectionFormFields
-          name={name}
-          description={description}
-          isPublic={isPublic}
-          onNameChange={handleNameChange}
-          onDescriptionChange={handleDescriptionChange}
-          onVisibilityChange={handleVisibilityChange}
-          onSetIsPublic={setIsPublic}
-          nameValidationState={nameValidationState}
-          nameErrorMessage={nameErrorMessage}
-          descriptionError={descriptionError}
-          isNameOverLimit={isNameOverLimit}
-          isDescriptionOverLimit={isDescriptionOverLimit}
-        />
-      </CollectionDialog>
+        onClose={() => setOpen(false)}
+      />
     </>
   );
 };

--- a/src/features/collections/createModal/hooks/useCollectionFormValidation.js
+++ b/src/features/collections/createModal/hooks/useCollectionFormValidation.js
@@ -72,7 +72,7 @@ export const useCollectionFormValidation = (
       return;
     }
 
-    if (name.length < 5) {
+    if (name.trim().length < 5) {
       setNameValidationState('warning');
       setNameErrorMessage('Collection name must be at least 5 characters');
       return;

--- a/src/features/collections/createWithDatasets/CreateCollectionWithDatasetsModal.js
+++ b/src/features/collections/createWithDatasets/CreateCollectionWithDatasetsModal.js
@@ -1,0 +1,280 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from '@material-ui/core';
+import { Close, Add } from '@material-ui/icons';
+import { useCreateWithDatasets } from './hooks/useCreateWithDatasets';
+import { useCreateWithDatasetsStyles } from './styles/createWithDatasetsStyles';
+import CollectionFormFields from '../components/CollectionFormFields';
+import CollectionDatasetsTable from '../components/CollectionDatasetsTable';
+import AddDatasetsModal from '../addDatasets/AddDatasetsModal';
+import ConfirmationDialog from '../../../shared/components/ConfirmationDialog';
+import UniversalButton from '../../../shared/components/UniversalButton';
+
+const CreateCollectionWithDatasetsModal = ({ open, onClose }) => {
+  const classes = useCreateWithDatasetsStyles();
+  const {
+    // Form state
+    name,
+    description,
+    isPublic,
+    handleNameChange,
+    handleDescriptionChange,
+    handleVisibilityChange,
+    setIsPublic,
+    // Validation
+    nameValidationState,
+    nameErrorMessage,
+    descriptionError,
+    isNameOverLimit,
+    isDescriptionOverLimit,
+    canSubmit,
+    // Dataset state
+    addedDatasets,
+    selectedDatasets,
+    showAddDatasetsModal,
+    setShowAddDatasetsModal,
+    showUnsavedWarning,
+    setShowUnsavedWarning,
+    isSubmitting,
+    // Handlers
+    handleAddDatasets,
+    handleRemoveDataset,
+    handleRemoveSelected,
+    handleToggleSelection,
+    handleSelectAll,
+    handleClearAll,
+    areAllSelected,
+    areIndeterminate,
+    handleSubmit,
+    resetAllState,
+  } = useCreateWithDatasets();
+
+  // Transform datasets for table
+  const datasetShortNamesWithStates = useMemo(() => {
+    return addedDatasets.map((dataset) => ({
+      shortName: dataset.shortName,
+      rowState: 'newlyAdded',
+    }));
+  }, [addedDatasets]);
+
+  // Handle close with unsaved check
+  const handleClose = () => {
+    const hasContent = name.trim() || addedDatasets.length > 0;
+
+    if (hasContent) {
+      setShowUnsavedWarning(true);
+    } else {
+      resetAllState();
+      onClose();
+    }
+  };
+
+  const handleKeepEditing = () => {
+    setShowUnsavedWarning(false);
+  };
+
+  const handleDiscardChanges = () => {
+    setShowUnsavedWarning(false);
+    resetAllState();
+    onClose();
+  };
+
+  const handleSaveClick = async () => {
+    const success = await handleSubmit();
+    if (success) {
+      onClose();
+    }
+  };
+
+  // Event wrapper handlers for CollectionFormFields
+  const handleNameChangeEvent = (event) => {
+    handleNameChange(event);
+  };
+
+  const handleDescriptionChangeEvent = (event) => {
+    handleDescriptionChange(event);
+  };
+
+  const handleVisibilityChangeEvent = (event) => {
+    handleVisibilityChange(event);
+  };
+
+  if (!open) return null;
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        classes={{ paper: classes.dialogPaper, root: classes.dialogRoot }}
+        maxWidth={false}
+        disableScrollLock={true}
+      >
+        <DialogTitle className={classes.dialogTitle}>
+          <Typography
+            variant="h4"
+            component="div"
+            className={classes.modalTitle}
+          >
+            Create New Collection
+          </Typography>
+          <IconButton onClick={handleClose} className={classes.closeButton}>
+            <Close />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent className={classes.dialogContent}>
+          <Box className={classes.splitPanelContainer}>
+            {/* LEFT PANEL */}
+            <Box className={classes.leftPanel}>
+              <CollectionFormFields
+                name={name}
+                description={description}
+                isPublic={isPublic}
+                onNameChange={handleNameChangeEvent}
+                onDescriptionChange={handleDescriptionChangeEvent}
+                onVisibilityChange={handleVisibilityChangeEvent}
+                onSetIsPublic={setIsPublic}
+                nameValidationState={nameValidationState}
+                nameErrorMessage={nameErrorMessage}
+                descriptionError={descriptionError}
+                isNameOverLimit={isNameOverLimit}
+                isDescriptionOverLimit={isDescriptionOverLimit}
+              />
+            </Box>
+
+            {/* RIGHT PANEL */}
+            <Box className={classes.rightPanel}>
+              <Box className={classes.sectionTitleRow}>
+                <Typography
+                  variant="subtitle1"
+                  style={{ color: '#ffffff', alignSelf: 'center' }}
+                >
+                  Adding {addedDatasets.length} dataset
+                  {addedDatasets.length === 1 ? '' : 's'}
+                </Typography>
+                <UniversalButton
+                  variant="containedPrimary"
+                  size="large"
+                  startIcon={<Add />}
+                  onClick={() => setShowAddDatasetsModal(true)}
+                >
+                  ADD DATASETS
+                </UniversalButton>
+              </Box>
+
+              <CollectionDatasetsTable
+                datasetShortNamesWithStates={datasetShortNamesWithStates}
+                selectedDatasets={selectedDatasets}
+                onToggleSelection={handleToggleSelection}
+                onSelectAll={handleSelectAll}
+                onClearAll={handleClearAll}
+                areAllSelected={areAllSelected}
+                areIndeterminate={areIndeterminate}
+                columns={['name', 'status', 'type', 'dateRange', 'rows']}
+                actions={[
+                  {
+                    label: 'Remove',
+                    onClick: (dataset) =>
+                      handleRemoveDataset(dataset.shortName),
+                    variant: 'secondary',
+                  },
+                ]}
+                maxHeight={500}
+              />
+
+              {/* Desktop Actions */}
+              <Box className={classes.inlineActions}>
+                <UniversalButton
+                  onClick={handleRemoveSelected}
+                  variant="secondary"
+                  size="large"
+                  disabled={selectedDatasets.length === 0}
+                >
+                  REMOVE SELECTED
+                </UniversalButton>
+                <Box style={{ flex: 1 }} />
+                <UniversalButton
+                  onClick={handleClose}
+                  variant="default"
+                  size="large"
+                >
+                  CANCEL
+                </UniversalButton>
+                <UniversalButton
+                  onClick={handleSaveClick}
+                  variant="primary"
+                  size="large"
+                  disabled={!canSubmit}
+                >
+                  {isSubmitting ? 'CREATING...' : 'CREATE COLLECTION'}
+                </UniversalButton>
+              </Box>
+            </Box>
+          </Box>
+        </DialogContent>
+
+        {/* Mobile Actions */}
+        <DialogActions className={classes.dialogActions}>
+          <UniversalButton
+            onClick={handleRemoveSelected}
+            variant="secondary"
+            size="large"
+            disabled={selectedDatasets.length === 0}
+          >
+            REMOVE SELECTED
+          </UniversalButton>
+          <Box style={{ flex: 1 }} />
+          <UniversalButton onClick={handleClose} variant="default" size="large">
+            CANCEL
+          </UniversalButton>
+          <UniversalButton
+            onClick={handleSaveClick}
+            variant="primary"
+            size="large"
+            disabled={!canSubmit}
+          >
+            {isSubmitting ? 'CREATING...' : 'CREATE COLLECTION'}
+          </UniversalButton>
+        </DialogActions>
+      </Dialog>
+
+      <AddDatasetsModal
+        open={showAddDatasetsModal}
+        onClose={() => setShowAddDatasetsModal(false)}
+        onAddDatasets={handleAddDatasets}
+        currentCollectionDatasets={addedDatasets}
+        targetCollectionName={name || 'New Collection'}
+      />
+
+      <ConfirmationDialog
+        open={showUnsavedWarning}
+        onClose={handleKeepEditing}
+        title="Unsaved Changes"
+        message="You have unsaved changes. If you leave now, your changes will be lost. Do you want to keep editing or discard your changes?"
+        actions={[
+          {
+            label: 'Keep Editing',
+            onClick: handleKeepEditing,
+            variant: 'primary',
+            autoFocus: true,
+          },
+          {
+            label: 'Discard Changes',
+            onClick: handleDiscardChanges,
+            variant: 'secondary',
+          },
+        ]}
+      />
+    </>
+  );
+};
+
+export default CreateCollectionWithDatasetsModal;

--- a/src/features/collections/createWithDatasets/hooks/useCreateWithDatasets.js
+++ b/src/features/collections/createWithDatasets/hooks/useCreateWithDatasets.js
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useCollectionForm } from '../../createModal/hooks/useCollectionForm';
+import { useCollectionFormValidation } from '../../createModal/hooks/useCollectionFormValidation';
+import useCollectionsStore from '../../state/collectionsStore';
+import { snackbarOpen } from '../../../../Redux/actions/ui';
+
+export const useCreateWithDatasets = () => {
+  const dispatch = useDispatch();
+
+  // Form state
+  const {
+    name,
+    description,
+    isPublic,
+    handleNameChange,
+    handleDescriptionChange,
+    handleVisibilityChange,
+    setIsPublic,
+    resetForm,
+  } = useCollectionForm();
+
+  // Validation
+  const verifyCollectionName = useCollectionsStore(
+    (state) => state.verifyCollectionName,
+  );
+  const {
+    nameValidationState,
+    nameErrorMessage,
+    descriptionError,
+    isValid,
+    resetValidation,
+  } = useCollectionFormValidation(name, description, verifyCollectionName);
+
+  // Local state
+  const [addedDatasets, setAddedDatasets] = useState([]); // Array of dataset objects
+  const [selectedDatasets, setSelectedDatasets] = useState([]); // Array of short names
+  const [showAddDatasetsModal, setShowAddDatasetsModal] = useState(false);
+  const [showUnsavedWarning, setShowUnsavedWarning] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Handlers
+  const handleAddDatasets = (newDatasets) => {
+    // Transform and merge, filtering duplicates by shortName
+    const datasetsWithFlags = newDatasets.map((dataset) => ({
+      ...dataset,
+      datasetShortName: dataset.shortName,
+      isNewlyAdded: true,
+    }));
+
+    const existingShortNames = new Set(addedDatasets.map((d) => d.shortName));
+    const uniqueNewDatasets = datasetsWithFlags.filter(
+      (d) => !existingShortNames.has(d.shortName),
+    );
+
+    setAddedDatasets([...addedDatasets, ...uniqueNewDatasets]);
+    setShowAddDatasetsModal(false);
+  };
+
+  const handleRemoveDataset = (shortName) => {
+    setAddedDatasets(addedDatasets.filter((d) => d.shortName !== shortName));
+    setSelectedDatasets(selectedDatasets.filter((s) => s !== shortName));
+  };
+
+  const handleRemoveSelected = () => {
+    if (selectedDatasets.length === 0) return;
+
+    const selectedSet = new Set(selectedDatasets);
+    setAddedDatasets(
+      addedDatasets.filter((d) => !selectedSet.has(d.shortName)),
+    );
+    setSelectedDatasets([]);
+  };
+
+  // Selection logic
+  const handleToggleSelection = (shortName) => {
+    setSelectedDatasets((prev) =>
+      prev.includes(shortName)
+        ? prev.filter((s) => s !== shortName)
+        : [...prev, shortName],
+    );
+  };
+
+  const handleSelectAll = () => {
+    setSelectedDatasets(addedDatasets.map((d) => d.shortName));
+  };
+
+  const handleClearAll = () => {
+    setSelectedDatasets([]);
+  };
+
+  const areAllSelected =
+    selectedDatasets.length === addedDatasets.length &&
+    addedDatasets.length > 0;
+  const areIndeterminate =
+    selectedDatasets.length > 0 &&
+    selectedDatasets.length < addedDatasets.length;
+
+  // Submit handler
+  const handleSubmit = async () => {
+    if (!canSubmit || isSubmitting) return false;
+
+    setIsSubmitting(true);
+    try {
+      const requestData = {
+        collectionName: name.trim(),
+        description: description || undefined,
+        private: !isPublic,
+        datasets: addedDatasets.map((d) => d.shortName),
+      };
+
+      await useCollectionsStore.getState().createCollection(requestData);
+
+      dispatch(
+        snackbarOpen('Collection created successfully', {
+          position: 'top',
+          severity: 'success',
+        }),
+      );
+
+      resetAllState();
+      return true;
+    } catch (error) {
+      let errorMessage = 'Failed to create collection. Please try again.';
+
+      if (error.message.includes('logged in')) {
+        errorMessage = 'You must be logged in to create collections';
+      } else if (error.message.includes('Network')) {
+        errorMessage = 'Network error. Please check your connection.';
+      }
+
+      dispatch(
+        snackbarOpen(errorMessage, {
+          position: 'top',
+          severity: 'error',
+        }),
+      );
+
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Reset all state
+  const resetAllState = () => {
+    resetForm();
+    resetValidation();
+    setAddedDatasets([]);
+    setSelectedDatasets([]);
+    setShowAddDatasetsModal(false);
+    setShowUnsavedWarning(false);
+  };
+
+  // Validation
+  const isNameOverLimit = name.length > 200;
+  const isDescriptionOverLimit = description.length > 500;
+  const canSubmit =
+    isValid && !isSubmitting && !isNameOverLimit && !isDescriptionOverLimit;
+
+  return {
+    // Form state
+    name,
+    description,
+    isPublic,
+    handleNameChange,
+    handleDescriptionChange,
+    handleVisibilityChange,
+    setIsPublic,
+    // Validation
+    nameValidationState,
+    nameErrorMessage,
+    descriptionError,
+    isNameOverLimit,
+    isDescriptionOverLimit,
+    canSubmit,
+    // Dataset state
+    addedDatasets,
+    selectedDatasets,
+    showAddDatasetsModal,
+    setShowAddDatasetsModal,
+    showUnsavedWarning,
+    setShowUnsavedWarning,
+    isSubmitting,
+    // Handlers
+    handleAddDatasets,
+    handleRemoveDataset,
+    handleRemoveSelected,
+    handleToggleSelection,
+    handleSelectAll,
+    handleClearAll,
+    areAllSelected,
+    areIndeterminate,
+    handleSubmit,
+    resetAllState,
+  };
+};

--- a/src/features/collections/createWithDatasets/styles/createWithDatasetsStyles.js
+++ b/src/features/collections/createWithDatasets/styles/createWithDatasetsStyles.js
@@ -1,0 +1,86 @@
+import { makeStyles } from '@material-ui/core/styles';
+import zIndex from '../../../../enums/zIndex';
+
+export const useCreateWithDatasetsStyles = makeStyles((theme) => ({
+  dialogPaper: {
+    width: '1400px',
+    maxWidth: '95vw',
+    maxHeight: '90vh',
+    backgroundColor: 'rgb(24, 69, 98)',
+  },
+  dialogRoot: {
+    zIndex: `${zIndex.MUI_DIALOG} !important`,
+  },
+  dialogTitle: {
+    paddingBottom: theme.spacing(1),
+    paddingTop: theme.spacing(2),
+    paddingRight: theme.spacing(6),
+  },
+  modalTitle: {
+    margin: 0,
+    fontWeight: 500,
+    fontSize: '1.5rem',
+    color: '#8bc34a',
+    flex: 1,
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+  dialogContent: {
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(2),
+  },
+  dialogActions: {
+    padding: theme.spacing(2),
+    paddingTop: theme.spacing(1),
+    gap: theme.spacing(1),
+    display: 'none',
+    [theme.breakpoints.down('md')]: {
+      display: 'flex',
+    },
+  },
+  inlineActions: {
+    display: 'flex',
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(2),
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
+  },
+  splitPanelContainer: {
+    display: 'grid',
+    gridTemplateColumns: '400px 1fr',
+    gap: theme.spacing(3),
+    alignItems: 'stretch',
+    [theme.breakpoints.down('md')]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+  leftPanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    paddingTop: theme.spacing(2),
+  },
+  sectionTitle: {
+    fontWeight: 500,
+    color: 'rgba(255, 255, 255, 0.9)',
+    marginBottom: theme.spacing(2),
+  },
+  sectionTitleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: theme.spacing(2),
+  },
+  rightPanel: {
+    backgroundColor: 'transparent',
+    boxShadow: 'none',
+    borderRadius: theme.shape.borderRadius,
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+  },
+}));

--- a/src/features/collections/editCollection/EditCollectionModal.js
+++ b/src/features/collections/editCollection/EditCollectionModal.js
@@ -163,6 +163,9 @@ const EditCollectionModal = ({ open, onClose, collectionId }) => {
   const cancelDatasetRemoval = useEditCollectionStore(
     (state) => state.cancelDatasetRemoval,
   );
+  const removeDatasetImmediate = useEditCollectionStore(
+    (state) => state.removeDatasetImmediate,
+  );
   const toggleDatasetSelection = useEditCollectionStore(
     (state) => state.toggleDatasetSelection,
   );
@@ -260,7 +263,18 @@ const EditCollectionModal = ({ open, onClose, collectionId }) => {
   const handleRemoveSelected = () => {
     if (selectedDatasets && selectedDatasets.length > 0) {
       selectedDatasets.forEach((datasetShortName) => {
-        markDatasetForRemoval(datasetShortName);
+        // Check if dataset is newly added
+        const collectionDataset = collection.datasets.find(
+          (d) => d.datasetShortName === datasetShortName,
+        );
+
+        if (collectionDataset?.isNewlyAdded === true) {
+          // Immediate removal for newly added datasets
+          removeDatasetImmediate(datasetShortName);
+        } else {
+          // Mark for removal for existing datasets
+          markDatasetForRemoval(datasetShortName);
+        }
       });
     }
   };
@@ -565,8 +579,20 @@ const EditCollectionModal = ({ open, onClose, collectionId }) => {
                 actions={[
                   {
                     label: 'Remove',
-                    onClick: (dataset) =>
-                      markDatasetForRemoval(dataset.shortName),
+                    onClick: (dataset) => {
+                      // Check if dataset is newly added
+                      const collectionDataset = collection.datasets.find(
+                        (d) => d.datasetShortName === dataset.shortName,
+                      );
+
+                      if (collectionDataset?.isNewlyAdded === true) {
+                        // Immediate removal for newly added datasets
+                        removeDatasetImmediate(dataset.shortName);
+                      } else {
+                        // Mark for removal for existing datasets
+                        markDatasetForRemoval(dataset.shortName);
+                      }
+                    },
                     variant: 'secondary',
                     condition: (dataset) =>
                       !datasetsToRemove.includes(dataset.shortName),

--- a/src/features/collections/state/editCollectionStore.js
+++ b/src/features/collections/state/editCollectionStore.js
@@ -162,6 +162,35 @@ const useEditCollectionStore = create((set, get) => ({
   },
 
   /**
+   * Immediately remove a newly added dataset from collection
+   * Used for datasets with isNewlyAdded flag to provide instant removal UX
+   * @param {string} datasetShortName - Dataset_Short_Name to remove
+   */
+  removeDatasetImmediate: (datasetShortName) => {
+    const { collection, selectedDatasets } = get();
+
+    if (!collection?.datasets) return;
+
+    // Remove from collection.datasets array
+    const updatedDatasets = collection.datasets.filter(
+      (dataset) => dataset.datasetShortName !== datasetShortName,
+    );
+
+    // Remove from selection if selected
+    const updatedSelection = selectedDatasets.filter(
+      (id) => id !== datasetShortName,
+    );
+
+    set({
+      collection: {
+        ...collection,
+        datasets: updatedDatasets,
+      },
+      selectedDatasets: updatedSelection,
+    });
+  },
+
+  /**
    * Toggle dataset selection (for checkbox state)
    * @param {string} datasetShortName - Dataset_Short_Name to toggle
    */

--- a/src/shared/UniversalSearch/components/SearchInput.js
+++ b/src/shared/UniversalSearch/components/SearchInput.js
@@ -9,7 +9,7 @@ import {
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { Autocomplete } from '@material-ui/lab';
-import { Search } from '@material-ui/icons';
+import { Search, ExpandMore, ExpandLess } from '@material-ui/icons';
 import InfoTooltip from '../../components/InfoTooltip';
 
 import {
@@ -198,9 +198,29 @@ const SearchInput = ({
   }, [clearSearch]);
 
   // Handle dropdown close (click outside, escape key, etc.)
-  const handleClose = useCallback(() => {
-    setDropdownOpen(false);
+  const handleClose = useCallback((event, reason) => {
+    // Only close on specific reasons, not on toggleInput or other input interactions
+    if (reason === 'escape' || reason === 'blur' || reason === 'selectOption') {
+      setDropdownOpen(false);
+    }
   }, []);
+
+  // Handle chevron icon click to toggle dropdown
+  const handleChevronClick = useCallback(
+    (event) => {
+      event.stopPropagation(); // Prevent event from bubbling
+      if (dropdownOpen) {
+        setDropdownOpen(false);
+      } else {
+        // Open dropdown and show all items if loadAllOnFocus is enabled
+        if (loadAllOnFocus && !inputValue) {
+          setShowAllOnFocus(true);
+        }
+        setDropdownOpen(true);
+      }
+    },
+    [dropdownOpen, loadAllOnFocus, inputValue],
+  );
 
   // Handle input focus - reopen dropdown if search is active or loadAllOnFocus is enabled
   const handleFocus = useCallback(() => {
@@ -328,6 +348,27 @@ const SearchInput = ({
                   <InputAdornment position="start">
                     <Search color="action" />
                   </InputAdornment>
+                </>
+              ),
+              endAdornment: (
+                <>
+                  <InputAdornment
+                    position="end"
+                    onClick={handleChevronClick}
+                    style={{
+                      marginRight: '-32px',
+                      cursor: 'pointer',
+                      zIndex: 1,
+                      pointerEvents: 'auto',
+                    }}
+                  >
+                    {dropdownOpen ? (
+                      <ExpandLess color="action" />
+                    ) : (
+                      <ExpandMore color="action" />
+                    )}
+                  </InputAdornment>
+                  {params.InputProps.endAdornment}
                 </>
               ),
             }}

--- a/src/shared/components/rowState/useRowStateStyles.js
+++ b/src/shared/components/rowState/useRowStateStyles.js
@@ -1,11 +1,5 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import {
-  CheckCircle as CheckCircleIcon,
-  Warning as WarningIcon,
-  AddCircle as AddCircleIcon,
-  RemoveCircle as RemoveCircleIcon,
-} from '@material-ui/icons';
 
 /**
  * Row state constants for dataset tables
@@ -70,50 +64,54 @@ const useStyles = makeStyles(() => ({
       backgroundColor: 'rgba(156, 39, 176, 0.15)',
     },
   },
-  // Status icon base styling
-  statusIcon: {
-    fontSize: '1.25rem',
-    verticalAlign: 'middle',
+  // Status label base styling
+  statusLabel: {
+    fontSize: '0.7rem',
+    fontWeight: 600,
+    lineHeight: '0.8rem',
+    textDecoration: 'none !important', // Override line-through from markedForRemoval row
+    display: 'inline-block',
   },
-  // Valid dataset icon (green check)
-  validIcon: {
-    color: '#8bc34a',
+  // Normal/empty state label (em dash placeholder)
+  normalLabel: {
+    color: 'rgba(255, 255, 255, 0.3)',
   },
-  // Invalid dataset icon (yellow warning)
-  invalidIcon: {
+  // Invalid dataset label (yellow)
+  invalidLabel: {
     color: '#ffc107',
   },
-  // Newly added icon (purple)
-  addedIcon: {
+  // Newly added label (purple)
+  addedLabel: {
     color: '#9c27b0',
   },
-  // Marked for removal icon (red)
-  removedIcon: {
+  // Marked for removal label (red)
+  removedLabel: {
     color: '#d32f2f',
   },
-  // Already present icon (gray)
-  alreadyPresentIcon: {
+  // Already present label (gray)
+  alreadyPresentLabel: {
     color: '#808080',
+    textAlign: 'center',
   },
 }));
 
 /**
- * Hook that provides row state styling and icon rendering for dataset tables
+ * Hook that provides row state styling and label rendering for dataset tables
  *
  * @returns {Object} Object containing:
  *   - getRowClassName: Function that returns CSS class string for a given row state
- *   - getStatusIcon: Function that returns JSX icon element for a given row state
+ *   - getStatusLabel: Function that returns JSX text label element for a given row state
  *   - ROW_STATES: Constant object with available row state values
  *   - classes: Material-UI classes object for advanced use cases
  *
  * @example
- * const { getRowClassName, getStatusIcon, ROW_STATES } = useRowStateStyles();
+ * const { getRowClassName, getStatusLabel, ROW_STATES } = useRowStateStyles();
  *
  * // Get row class name
  * const rowClass = getRowClassName(ROW_STATES.INVALID);
  *
- * // Render status icon
- * const icon = getStatusIcon(ROW_STATES.NORMAL);
+ * // Render status label
+ * const label = getStatusLabel(ROW_STATES.NORMAL);
  */
 export const useRowStateStyles = () => {
   const classes = useStyles();
@@ -143,52 +141,55 @@ export const useRowStateStyles = () => {
   };
 
   /**
-   * Get status icon JSX element for a row based on its state
+   * Get status label JSX element for a row based on its state
    *
    * Priority order: markedForRemoval > invalid > newlyAdded > alreadyPresent > normal
    *
    * @param {string} rowState - One of ROW_STATES values
-   * @returns {JSX.Element} Icon component with appropriate styling
+   * @returns {JSX.Element} Text label component with appropriate styling, or em dash for normal state
    */
-  const getStatusIcon = (rowState) => {
+  const getStatusLabel = (rowState) => {
     switch (rowState) {
       case ROW_STATES.MARKED_FOR_REMOVAL:
         return (
-          <RemoveCircleIcon
-            className={`${classes.statusIcon} ${classes.removedIcon}`}
-          />
+          <span className={`${classes.statusLabel} ${classes.removedLabel}`}>
+            To Be Removed
+          </span>
         );
       case ROW_STATES.INVALID:
         return (
-          <WarningIcon
-            className={`${classes.statusIcon} ${classes.invalidIcon}`}
-          />
+          <span className={`${classes.statusLabel} ${classes.invalidLabel}`}>
+            Not Available
+          </span>
         );
       case ROW_STATES.NEWLY_ADDED:
         return (
-          <AddCircleIcon
-            className={`${classes.statusIcon} ${classes.addedIcon}`}
-          />
+          <span className={`${classes.statusLabel} ${classes.addedLabel}`}>
+            To Be Added
+          </span>
         );
       case ROW_STATES.ALREADY_PRESENT:
         return (
-          <RemoveCircleIcon
-            className={`${classes.statusIcon} ${classes.alreadyPresentIcon}`}
-          />
+          <span
+            className={`${classes.statusLabel} ${classes.alreadyPresentLabel}`}
+          >
+            Already in Collection
+          </span>
         );
       case ROW_STATES.NORMAL:
       default:
         return (
-          <CheckCircleIcon
-            className={`${classes.statusIcon} ${classes.validIcon}`}
-          />
+          <span className={`${classes.statusLabel} ${classes.normalLabel}`}>
+            —
+          </span>
         );
     }
   };
 
   return {
     getRowClassName,
-    getStatusIcon,
+    getStatusLabel,
+    getStatusIcon: getStatusLabel, // Backward compatibility alias
     ROW_STATES,
     classes,
   };

--- a/src/shared/estimation/__tests__/estimateRowCount.test.js
+++ b/src/shared/estimation/__tests__/estimateRowCount.test.js
@@ -1,0 +1,355 @@
+/**
+ * Integration Tests for Row Count Estimation
+ *
+ * Tests the estimateRowCount function with various constraint combinations
+ * to verify correct calculation of spatial, temporal, and depth dimensions.
+ *
+ * Test Coverage:
+ * - Test 1: Spatial only
+ * - Test 2: Spatial + Temporal (Daily)
+ * - Test 3: Spatial + Temporal + Depth (Darwin)
+ * - Test 4: Spatial + Monthly Climatology
+ * - Test 5: Spatial + Temporal + Depth (PISCES)
+ */
+
+import estimateRowCount from '../estimateRowCount';
+import * as queryTables from '../queryEstimationTables';
+
+// Mock the query functions
+jest.mock('../queryEstimationTables');
+
+describe('estimateRowCount - Integration Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Test 1: Spatial Only
+   *
+   * Dataset: 1° × 1° resolution
+   * Constraints: lat 0→10, lon 0→10
+   * Calculation:
+   *   - latCount = (10 - 0) / 1.0 = 10
+   *   - lonCount = (10 - 0) / 1.0 = 10
+   *   - dateCount = 1 (no temporal constraints)
+   *   - depthCount = 1 (no depth constraints)
+   *   - Total = 10 × 10 × 1 × 1 = 100
+   */
+  it('Test 1: should estimate row count for spatial-only constraints', async () => {
+    // Arrange: Mock resolution mappings
+    queryTables.querySpatialResolutionMapping.mockResolvedValue({
+      value: 1.0,
+      units: 'degrees',
+    });
+
+    // Mock temporal resolution even though not used (code queries it)
+    queryTables.queryTemporalResolutionMapping.mockResolvedValue({
+      value: null,
+      units: null,
+    });
+
+    const datasetMetadata = {
+      Table_Name: 'test_dataset_spatial',
+      Spatial_Resolution: '1° X 1°',
+      Temporal_Resolution: 'Irregular',
+    };
+
+    const constraints = {
+      spatialBounds: { latMin: 0, latMax: 10, lonMin: 0, lonMax: 10 },
+      temporalEnabled: false,
+      temporalRange: { timeMin: null, timeMax: null },
+      depthEnabled: false,
+      depthRange: { depthMin: null, depthMax: null },
+    };
+
+    const mockDb = {}; // Not used, just passed through
+
+    // Act
+    const result = await estimateRowCount(datasetMetadata, constraints, mockDb);
+
+    // Assert
+    const expected = 100;
+    expect(Math.round(result)).toBe(expected);
+
+    // Verify mocks were called correctly
+    expect(queryTables.querySpatialResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      '1° X 1°'
+    );
+  });
+
+  /**
+   * Test 2: Spatial + Temporal (Daily)
+   *
+   * Dataset: 1° × 1° resolution, Daily temporal resolution
+   * Constraints: lat 0→10, lon 0→10, Jan 1-10, 2020 (9 days)
+   * Calculation:
+   *   - latCount = (10 - 0) / 1.0 = 10
+   *   - lonCount = (10 - 0) / 1.0 = 10
+   *   - dayDiff = 9 days
+   *   - dateCount = floor(9 / 1) × 1.4 = 9 × 1.4 = 12.6
+   *   - depthCount = 1
+   *   - Total = 10 × 10 × 12.6 × 1 = 1,260
+   */
+  it('Test 2: should estimate row count for spatial + temporal (daily)', async () => {
+    // Arrange: Mock resolution mappings
+    queryTables.querySpatialResolutionMapping.mockResolvedValue({
+      value: 1.0,
+      units: 'degrees',
+    });
+
+    queryTables.queryTemporalResolutionMapping.mockResolvedValue({
+      value: 86400, // Daily in seconds
+      units: 'seconds',
+    });
+
+    const datasetMetadata = {
+      Table_Name: 'test_dataset_daily',
+      Spatial_Resolution: '1° X 1°',
+      Temporal_Resolution: 'Daily',
+    };
+
+    const constraints = {
+      spatialBounds: { latMin: 0, latMax: 10, lonMin: 0, lonMax: 10 },
+      temporalEnabled: true,
+      temporalRange: {
+        timeMin: '2020-01-01T00:00:00Z',
+        timeMax: '2020-01-10T00:00:00Z',
+      },
+      depthEnabled: false,
+      depthRange: { depthMin: null, depthMax: null },
+    };
+
+    const mockDb = {};
+
+    // Act
+    const result = await estimateRowCount(datasetMetadata, constraints, mockDb);
+
+    // Assert
+    const expected = 1260;
+    expect(Math.round(result)).toBe(expected);
+
+    // Verify mocks
+    expect(queryTables.querySpatialResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      '1° X 1°'
+    );
+    expect(queryTables.queryTemporalResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      'Daily'
+    );
+  });
+
+  /**
+   * Test 3: Spatial + Temporal + Depth (Darwin)
+   *
+   * Dataset: 1/2° × 1/2° resolution, Weekly temporal, Darwin depth model
+   * Constraints: lat 0→10, lon 0→20, 363 days (51.85 weeks), depth 5-105.31m
+   * Calculation:
+   *   - latCount = (10 - 0) / 0.5 = 20
+   *   - lonCount = (20 - 0) / 0.5 = 40
+   *   - dayDiff = 363 days (Jan 1 - Dec 29, 2020)
+   *   - dateCount = floor(363 / 7) × 1.4 = 51 × 1.4 = 71.4
+   *   - depthCount = 10 (Darwin depths in range 5-105.31)
+   *   - Total = 20 × 40 × 71.4 × 10 = 571,200
+   */
+  it('Test 3: should estimate row count for spatial + temporal + depth (Darwin)', async () => {
+    // Arrange: Mock all resolution mappings and depth queries
+    queryTables.querySpatialResolutionMapping.mockResolvedValue({
+      value: 0.5,
+      units: 'degrees',
+    });
+
+    queryTables.queryTemporalResolutionMapping.mockResolvedValue({
+      value: 604800, // Weekly in seconds
+      units: 'seconds',
+    });
+
+    queryTables.queryDatasetDepthModel.mockResolvedValue('darwin');
+
+    queryTables.queryDarwinDepthCount.mockResolvedValue(10);
+
+    const datasetMetadata = {
+      Table_Name: 'tblDarwin_Test',
+      Spatial_Resolution: '1/2° X 1/2°',
+      Temporal_Resolution: 'Weekly',
+    };
+
+    const constraints = {
+      spatialBounds: { latMin: 0, latMax: 10, lonMin: 0, lonMax: 20 },
+      temporalEnabled: true,
+      temporalRange: {
+        timeMin: '2020-01-01T00:00:00Z',
+        timeMax: '2020-12-29T00:00:00Z', // 364 days (52 weeks)
+      },
+      depthEnabled: true,
+      depthRange: { depthMin: 5, depthMax: 105.31 },
+    };
+
+    const mockDb = {};
+
+    // Act
+    const result = await estimateRowCount(datasetMetadata, constraints, mockDb);
+
+    // Assert
+    const expected = 571200;
+    expect(Math.round(result)).toBe(expected);
+
+    // Verify mocks
+    expect(queryTables.querySpatialResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      '1/2° X 1/2°'
+    );
+    expect(queryTables.queryTemporalResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      'Weekly'
+    );
+    expect(queryTables.queryDatasetDepthModel).toHaveBeenCalledWith(
+      mockDb,
+      'tblDarwin_Test'
+    );
+    expect(queryTables.queryDarwinDepthCount).toHaveBeenCalledWith(
+      mockDb,
+      5,
+      105.31
+    );
+  });
+
+  /**
+   * Test 4: Spatial + Monthly Climatology
+   *
+   * Dataset: 1/4° × 1/4° resolution, Monthly Climatology
+   * Constraints: lat -5→5, lon -10→10, Jan 1 → Dec 31, 2020 (12 months)
+   * Calculation:
+   *   - latCount = (5 - (-5)) / 0.25 = 10 / 0.25 = 40
+   *   - lonCount = (10 - (-10)) / 0.25 = 20 / 0.25 = 80
+   *   - monthCount = 12 (full year → all 12 months)
+   *   - dateCount = 12 × 1.4 = 16.8
+   *   - depthCount = 1
+   *   - Total = 40 × 80 × 16.8 × 1 = 53,760
+   */
+  it('Test 4: should estimate row count for spatial + monthly climatology', async () => {
+    // Arrange: Mock resolution mappings
+    queryTables.querySpatialResolutionMapping.mockResolvedValue({
+      value: 0.25,
+      units: 'degrees',
+    });
+
+    // Monthly Climatology returns null for temporal mapping
+    queryTables.queryTemporalResolutionMapping.mockResolvedValue({
+      value: null,
+      units: null,
+    });
+
+    const datasetMetadata = {
+      Table_Name: 'test_dataset_climatology',
+      Spatial_Resolution: '1/4° X 1/4°',
+      Temporal_Resolution: 'Monthly Climatology',
+    };
+
+    const constraints = {
+      spatialBounds: { latMin: -5, latMax: 5, lonMin: -10, lonMax: 10 },
+      temporalEnabled: true,
+      temporalRange: {
+        timeMin: '2020-01-01T00:00:00Z',
+        timeMax: '2020-12-31T23:59:59Z',
+      },
+      depthEnabled: false,
+      depthRange: { depthMin: null, depthMax: null },
+    };
+
+    const mockDb = {};
+
+    // Act
+    const result = await estimateRowCount(datasetMetadata, constraints, mockDb);
+
+    // Assert
+    const expected = 53760;
+    expect(Math.round(result)).toBe(expected);
+
+    // Verify mocks
+    expect(queryTables.querySpatialResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      '1/4° X 1/4°'
+    );
+    expect(queryTables.queryTemporalResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      'Monthly Climatology'
+    );
+  });
+
+  /**
+   * Test 5: Spatial + Temporal + Depth (PISCES)
+   *
+   * Dataset: 1/12° × 1/12° resolution, Monthly temporal, PISCES depth model
+   * Constraints: lat 30→35, lon -130→-120, 12 months, depth 0-100m
+   * Calculation:
+   *   - latCount = (35 - 30) / 0.083333 = 5 / 0.083333 ≈ 60.0002
+   *   - lonCount = (-120 - (-130)) / 0.083333 = 10 / 0.083333 ≈ 120.0005
+   *   - dayDiff = 365 days (Jan 1 - Dec 31, 2020)
+   *   - dateCount = floor(365 / 30) × 1.4 = 12 × 1.4 = 16.8
+   *   - depthCount = 22 (PISCES depths in range 0-100)
+   *   - Total ≈ 60.0002 × 120.0005 × 16.8 × 22 = 2,661,141
+   */
+  it('Test 5: should estimate row count for spatial + temporal + depth (PISCES)', async () => {
+    // Arrange: Mock all resolution mappings and depth queries
+    queryTables.querySpatialResolutionMapping.mockResolvedValue({
+      value: 0.083333,
+      units: 'degrees',
+    });
+
+    queryTables.queryTemporalResolutionMapping.mockResolvedValue({
+      value: 2592000, // Monthly in seconds
+      units: 'seconds',
+    });
+
+    queryTables.queryDatasetDepthModel.mockResolvedValue('pisces');
+
+    queryTables.queryPiscesDepthCount.mockResolvedValue(22);
+
+    const datasetMetadata = {
+      Table_Name: 'tblPisces_Test',
+      Spatial_Resolution: '1/12° X 1/12°',
+      Temporal_Resolution: 'Monthly',
+    };
+
+    const constraints = {
+      spatialBounds: { latMin: 30, latMax: 35, lonMin: -130, lonMax: -120 },
+      temporalEnabled: true,
+      temporalRange: {
+        timeMin: '2020-01-01T00:00:00Z',
+        timeMax: '2020-12-31T23:59:59Z',
+      },
+      depthEnabled: true,
+      depthRange: { depthMin: 0, depthMax: 100 },
+    };
+
+    const mockDb = {};
+
+    // Act
+    const result = await estimateRowCount(datasetMetadata, constraints, mockDb);
+
+    // Assert
+    const expected = 2661141;
+    expect(Math.round(result)).toBe(expected);
+
+    // Verify mocks
+    expect(queryTables.querySpatialResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      '1/12° X 1/12°'
+    );
+    expect(queryTables.queryTemporalResolutionMapping).toHaveBeenCalledWith(
+      mockDb,
+      'Monthly'
+    );
+    expect(queryTables.queryDatasetDepthModel).toHaveBeenCalledWith(
+      mockDb,
+      'tblPisces_Test'
+    );
+    expect(queryTables.queryPiscesDepthCount).toHaveBeenCalledWith(
+      mockDb,
+      0,
+      100
+    );
+  });
+});

--- a/src/shared/estimation/estimateRowCount.js
+++ b/src/shared/estimation/estimateRowCount.js
@@ -1,0 +1,251 @@
+/**
+ * Frontend Row Count Estimation
+ *
+ * Pure calculation functions for estimating dataset row counts based on
+ * spatial, temporal, and depth constraints. Replicates logic from the legacy
+ * estimateDataSize.js but adapted for Collections feature.
+ *
+ * IMPORTANT: The calling function must check eligibility BEFORE calling estimateRowCount.
+ * Use isEligibleForEstimation() to determine if a dataset can be estimated.
+ *
+ * Key differences from legacy estimateDataSize.js:
+ * - No /200 division (Collections doesn't use visualization types)
+ * - Works with SQLite resolution mappings instead of hardcoded enums
+ * - Uses pure functions for calculations (testable, maintainable)
+ */
+
+import logInit from '../../Services/log-service';
+import {
+  querySpatialResolutionMapping,
+  queryTemporalResolutionMapping,
+  queryDatasetDepthModel,
+  queryDarwinDepthCount,
+  queryPiscesDepthCount,
+} from './queryEstimationTables';
+
+const log = logInit('shared/estimation/estimateRowCount');
+
+/**
+ * Calculate spatial grid cell count (pure function).
+ *
+ * Handles longitude wraparound when lon2 < lon1 (date line crossing).
+ *
+ * @param {Object} constraints - Store constraints object
+ * @param {Object} constraints.spatialBounds - Spatial bounds { latMin, latMax, lonMin, lonMax }
+ * @param {number} spatialResolutionDegrees - Spatial resolution in degrees
+ * @returns {{ latCount: number, lonCount: number }} Grid cell counts
+ */
+function calculateSpatialCount(constraints, spatialResolutionDegrees) {
+  const { latMin, latMax, lonMin, lonMax } = constraints.spatialBounds;
+
+  const latCount = (latMax - latMin) / spatialResolutionDegrees;
+
+  // Handle longitude wraparound (date line crossing)
+  const lonCount =
+    lonMax > lonMin
+      ? (lonMax - lonMin) / spatialResolutionDegrees
+      : (180 - lonMin + (lonMax + 180)) / spatialResolutionDegrees;
+
+  return { latCount, lonCount };
+}
+
+/**
+ * Calculate month count for Monthly Climatology datasets (pure function).
+ *
+ * Infers the number of months based on the date range:
+ * - If range >= 12 months, all 12 months are covered
+ * - Otherwise, counts the specific months from start to end
+ *
+ * @param {Date} startDate - Start date
+ * @param {Date} endDate - End date
+ * @returns {number} Number of months (1-12)
+ */
+function calculateMonthlyClimatologyCount(startDate, endDate) {
+  const startMonth = startDate.getMonth(); // 0-11
+  const endMonth = endDate.getMonth();
+  const startYear = startDate.getFullYear();
+  const endYear = endDate.getFullYear();
+
+  // Total months from start to end (inclusive)
+  const totalMonthSpan =
+    (endYear - startYear) * 12 + (endMonth - startMonth) + 1;
+
+  // If >= 12 months, all 12 are covered
+  if (totalMonthSpan >= 12) {
+    return 12;
+  }
+
+  return totalMonthSpan;
+}
+
+/**
+ * Calculate temporal count with Monthly Climatology support (pure function).
+ *
+ * Applies 1.4x multiplier for SQL indexing weight (origin unknown, preserved from legacy).
+ *
+ * @param {Object} constraints - Store constraints object
+ * @param {Object} constraints.temporalRange - Temporal range { timeMin, timeMax }
+ * @param {number} temporalResolutionDays - Temporal resolution in days
+ * @param {boolean} isMonthlyClimatology - Whether dataset uses Monthly Climatology
+ * @returns {number} Temporal count (with 1.4x multiplier applied)
+ */
+function calculateTemporalCount(
+  constraints,
+  temporalResolutionDays,
+  isMonthlyClimatology,
+) {
+  const date1 = new Date(constraints.temporalRange.timeMin);
+  const date2 = new Date(constraints.temporalRange.timeMax);
+
+  let dateCount;
+
+  if (isMonthlyClimatology) {
+    // Monthly Climatology: infer months from date range
+    // If range >= 1 year, all 12 months are covered
+    // Otherwise, count the specific months from start to end
+    dateCount = calculateMonthlyClimatologyCount(date1, date2);
+  } else {
+    // Regular temporal resolution: count intervals
+    const dayDiff = (date2 - date1) / 86400000; // milliseconds to days
+    dateCount = Math.floor(dayDiff / temporalResolutionDays) || 1;
+  }
+
+  // Apply SQL indexing weight (1.4x multiplier)
+  // Origin unknown, but preserved from legacy estimateDataSize.js
+  dateCount *= 1.4;
+
+  return dateCount;
+}
+
+/**
+ * Main estimation orchestrator (not pure, async).
+ *
+ * Combines spatial, temporal, and depth calculations to estimate row count.
+ * Queries SQLite catalog database for resolution mappings and depth models.
+ *
+ * IMPORTANT: Call isEligibleForEstimation() BEFORE calling this function.
+ * This function assumes all inputs are valid for estimation.
+ *
+ * @param {Object} datasetMetadata - Dataset metadata
+ * @param {string} datasetMetadata.Spatial_Resolution - Spatial resolution (e.g., "1/2° X 1/2°")
+ * @param {string} datasetMetadata.Temporal_Resolution - Temporal resolution (e.g., "Weekly")
+ * @param {string} datasetMetadata.Table_Name - Dataset table name
+ * @param {Object} constraints - Store constraints object
+ * @param {Object} constraints.spatialBounds - Spatial bounds { latMin, latMax, lonMin, lonMax }
+ * @param {boolean} constraints.temporalEnabled - Whether temporal constraints are enabled
+ * @param {Object} constraints.temporalRange - Temporal range { timeMin, timeMax }
+ * @param {boolean} constraints.depthEnabled - Whether depth constraints are enabled
+ * @param {Object} constraints.depthRange - Depth range { depthMin, depthMax }
+ * @param {Object} catalogDb - SQLite catalog database API instance
+ * @returns {Promise<number>} Estimated row count
+ * @throws {Error} If resolution mappings not found or database queries fail
+ */
+async function estimateRowCount(datasetMetadata, constraints, catalogDb) {
+  try {
+    log.debug('starting row count estimation', {
+      dataset: datasetMetadata.Table_Name,
+      spatialResolution: datasetMetadata.Spatial_Resolution,
+      temporalResolution: datasetMetadata.Temporal_Resolution,
+      constraints,
+    });
+
+    // Step 1: Query resolution mappings from SQLite
+    const spatialMapping = await querySpatialResolutionMapping(
+      catalogDb,
+      datasetMetadata.Spatial_Resolution,
+    );
+    const temporalMapping = await queryTemporalResolutionMapping(
+      catalogDb,
+      datasetMetadata.Temporal_Resolution,
+    );
+
+    if (!spatialMapping || spatialMapping.value === null) {
+      throw new Error(
+        `Spatial resolution mapping not found: ${datasetMetadata.Spatial_Resolution}`,
+      );
+    }
+
+    // Temporal mapping can be null for Monthly Climatology (handled below)
+    const isMonthlyClimatology =
+      datasetMetadata.Temporal_Resolution === 'Monthly Climatology';
+
+    if (
+      !isMonthlyClimatology &&
+      (!temporalMapping || temporalMapping.value === null)
+    ) {
+      throw new Error(
+        `Temporal resolution mapping not found: ${datasetMetadata.Temporal_Resolution}`,
+      );
+    }
+
+    // Step 2: Calculate spatial count (pure function)
+    const { latCount, lonCount } = calculateSpatialCount(
+      constraints,
+      spatialMapping.value,
+    );
+
+    // Step 3: Calculate temporal count (pure function)
+    // Convert temporal resolution from seconds to days
+    const temporalResolutionDays = isMonthlyClimatology
+      ? 0 // Not used for Monthly Climatology
+      : temporalMapping.value / 86400; // seconds to days
+
+    const dateCount = calculateTemporalCount(
+      constraints,
+      temporalResolutionDays,
+      isMonthlyClimatology,
+    );
+
+    // Step 4: Calculate depth count (async, queries database)
+    let depthCount = 1; // Default: no depth dimension
+
+    const hasDepthConstraints =
+      constraints.depthEnabled &&
+      constraints.depthRange.depthMin !== null &&
+      constraints.depthRange.depthMax !== null;
+
+    if (hasDepthConstraints) {
+      const depthModel = await queryDatasetDepthModel(
+        catalogDb,
+        datasetMetadata.Table_Name,
+      );
+
+      if (depthModel === 'darwin') {
+        depthCount = await queryDarwinDepthCount(
+          catalogDb,
+          constraints.depthRange.depthMin,
+          constraints.depthRange.depthMax,
+        );
+      } else if (depthModel === 'pisces') {
+        depthCount = await queryPiscesDepthCount(
+          catalogDb,
+          constraints.depthRange.depthMin,
+          constraints.depthRange.depthMax,
+        );
+      }
+      // If depthModel is null (not Darwin/PISCES), depthCount stays 1
+    }
+
+    // Step 5: Combine counts to estimate total row count
+    const pointCount = lonCount * latCount * depthCount * dateCount;
+
+    log.debug('row count estimation complete', {
+      dataset: datasetMetadata.Table_Name,
+      latCount,
+      lonCount,
+      dateCount,
+      depthCount,
+      pointCount,
+    });
+
+    return Math.round(pointCount);
+  } catch (error) {
+    log.error('row count estimation failed', {
+      dataset: datasetMetadata.Table_Name,
+      error: error.message,
+    });
+    throw error;
+  }
+}
+
+export default estimateRowCount;

--- a/src/shared/estimation/isEligibleForEstimation.js
+++ b/src/shared/estimation/isEligibleForEstimation.js
@@ -1,0 +1,58 @@
+/**
+ * Determines if a dataset is eligible for frontend size estimation.
+ *
+ * @param {Object} datasetMetadata - Dataset metadata from catalog
+ * @param {string} datasetMetadata.spatialResolution - Spatial resolution (e.g., "1/2° X 1/2°", "Irregular")
+ * @param {string} datasetMetadata.temporalResolution - Temporal resolution (e.g., "Weekly", "Irregular")
+ * @param {string} datasetMetadata.tableName - Dataset table name (e.g., "tblDarwin_Nutrient")
+ * @param {Object} constraints - Store constraints object
+ * @param {Object} constraints.spatialBounds - Spatial bounds { latMin, latMax, lonMin, lonMax }
+ * @param {boolean} constraints.temporalEnabled - Whether temporal constraints are enabled
+ * @param {Object} constraints.temporalRange - Temporal range { timeMin, timeMax }
+ * @param {boolean} constraints.depthEnabled - Whether depth constraints are enabled
+ * @param {Object} constraints.depthRange - Depth range { depthMin, depthMax }
+ * @returns {boolean} True if dataset is eligible for frontend estimation
+ */
+function isEligibleForEstimation(datasetMetadata, constraints) {
+  const { spatialResolution, temporalResolution, tableName } = datasetMetadata;
+
+  // Check 1: Spatial resolution (ALWAYS required)
+  if (spatialResolution === 'Irregular') {
+    return false;
+  }
+
+  // Check 2: Temporal resolution (only if temporal constraints are active)
+  const hasTemporalConstraints =
+    constraints.temporalEnabled &&
+    constraints.temporalRange.timeMin &&
+    constraints.temporalRange.timeMax;
+
+  if (hasTemporalConstraints) {
+    // Only reject 'Irregular'
+    // Note: 'Monthly Climatology' is eligible despite having null value in mapping table
+    if (temporalResolution === 'Irregular') {
+      return false;
+    }
+  }
+
+  // Check 3: Depth support (only if depth constraints are active)
+  const hasDepthConstraints =
+    constraints.depthEnabled &&
+    constraints.depthRange.depthMin !== null &&
+    constraints.depthRange.depthMax !== null;
+
+  if (hasDepthConstraints) {
+    const tableNameLower = tableName.toLowerCase();
+    const supportsDarwin = tableNameLower.includes('darwin');
+    const supportsPisces = tableNameLower.includes('pisces');
+
+    if (!supportsDarwin && !supportsPisces) {
+      return false;
+    }
+  }
+
+  // All applicable checks passed
+  return true;
+}
+
+export default isEligibleForEstimation;

--- a/src/shared/estimation/queryEstimationTables.js
+++ b/src/shared/estimation/queryEstimationTables.js
@@ -1,0 +1,210 @@
+/**
+ * Query Estimation Tables
+ *
+ * Provides interface to query SQLite catalog database estimation tables.
+ * These tables support frontend row count estimation for datasets with
+ * regular spatial/temporal resolution.
+ *
+ * Tables queried:
+ * - spatial_resolution_mappings: resolution → {value (degrees), units} (units null for irregular)
+ * - temporal_resolution_mappings: resolution → {value (seconds), units} (units null for irregular)
+ * - dataset_depth_models: dataset short name → depth model (darwin/pisces)
+ * - darwin_depth: Darwin depth levels
+ * - pisces_depth: PISCES depth levels
+ *
+ * All functions use the catalog search Web Worker's executeSql interface.
+ */
+
+import logInit from '../../Services/log-service';
+
+const log = logInit('shared/estimation/queryEstimationTables');
+
+/**
+ * Query spatial resolution mapping table
+ * @param {Object} searchDatabaseApi - Initialized SearchDatabaseApi instance
+ * @param {string} resolution - Spatial resolution string (e.g., "1/2° X 1/2°")
+ * @returns {Promise<{value: number|null, units: string|null}|null>} Object with numeric degree value and units, or null if not found
+ */
+export async function querySpatialResolutionMapping(
+  searchDatabaseApi,
+  resolution,
+) {
+  try {
+    log.debug('querying spatial resolution mapping', { resolution });
+
+    const sql =
+      'SELECT value, units FROM spatial_resolution_mappings WHERE resolution = ?';
+    const bindings = [resolution];
+
+    const results = await searchDatabaseApi.executeSql(sql, bindings);
+
+    if (results.length === 0) {
+      log.debug('spatial resolution not found in mappings', { resolution });
+      return null;
+    }
+
+    const result = {
+      value: results[0].value,
+      units: results[0].units,
+    };
+    log.debug('spatial resolution mapping found', {
+      resolution,
+      ...result,
+    });
+
+    return result;
+  } catch (error) {
+    log.error('error querying spatial resolution mapping', {
+      resolution,
+      error: error.message,
+    });
+    return null;
+  }
+}
+
+/**
+ * Query temporal resolution mapping table
+ * @param {Object} searchDatabaseApi - Initialized SearchDatabaseApi instance
+ * @param {string} resolution - Temporal resolution string (e.g., "Weekly")
+ * @returns {Promise<{value: number|null, units: string|null}|null>} Object with numeric seconds value and units, or null if not found
+ */
+export async function queryTemporalResolutionMapping(
+  searchDatabaseApi,
+  resolution,
+) {
+  try {
+    log.debug('querying temporal resolution mapping', { resolution });
+
+    const sql =
+      'SELECT value, units FROM temporal_resolution_mappings WHERE resolution = ?';
+    const bindings = [resolution];
+
+    const results = await searchDatabaseApi.executeSql(sql, bindings);
+
+    if (results.length === 0) {
+      log.debug('temporal resolution not found in mappings', { resolution });
+      return null;
+    }
+
+    const result = {
+      value: results[0].value,
+      units: results[0].units,
+    };
+    log.debug('temporal resolution mapping found', {
+      resolution,
+      ...result,
+    });
+
+    return result;
+  } catch (error) {
+    log.error('error querying temporal resolution mapping', {
+      resolution,
+      error: error.message,
+    });
+    return null;
+  }
+}
+
+/**
+ * Query dataset depth model table
+ * @param {Object} searchDatabaseApi - Initialized SearchDatabaseApi instance
+ * @param {string} shortName - Dataset short name
+ * @returns {Promise<string|null>} Depth model ("darwin" or "pisces") or null if not found
+ */
+export async function queryDatasetDepthModel(searchDatabaseApi, shortName) {
+  try {
+    log.debug('querying dataset depth model', { shortName });
+
+    const sql =
+      'SELECT depth_model FROM dataset_depth_models WHERE short_name = ?';
+    const bindings = [shortName];
+
+    const results = await searchDatabaseApi.executeSql(sql, bindings);
+
+    if (results.length === 0) {
+      log.debug('dataset depth model not found', { shortName });
+      return null;
+    }
+
+    const depthModel = results[0].depth_model;
+    log.debug('dataset depth model found', { shortName, depthModel });
+
+    return depthModel;
+  } catch (error) {
+    log.error('error querying dataset depth model', {
+      shortName,
+      error: error.message,
+    });
+    return null;
+  }
+}
+
+/**
+ * Count Darwin depth levels within range
+ * @param {Object} searchDatabaseApi - Initialized SearchDatabaseApi instance
+ * @param {number} minDepth - Minimum depth in meters
+ * @param {number} maxDepth - Maximum depth in meters
+ * @returns {Promise<number>} Count of depth levels within range
+ */
+export async function queryDarwinDepthCount(
+  searchDatabaseApi,
+  minDepth,
+  maxDepth,
+) {
+  try {
+    log.debug('querying darwin depth count', { minDepth, maxDepth });
+
+    const sql =
+      'SELECT COUNT(*) as count FROM darwin_depth WHERE depth_level BETWEEN ? AND ?';
+    const bindings = [minDepth, maxDepth];
+
+    const results = await searchDatabaseApi.executeSql(sql, bindings);
+
+    const count = results[0].count;
+    log.debug('darwin depth count', { minDepth, maxDepth, count });
+
+    return count;
+  } catch (error) {
+    log.error('error querying darwin depth count', {
+      minDepth,
+      maxDepth,
+      error: error.message,
+    });
+    return 0;
+  }
+}
+
+/**
+ * Count PISCES depth levels within range
+ * @param {Object} searchDatabaseApi - Initialized SearchDatabaseApi instance
+ * @param {number} minDepth - Minimum depth in meters
+ * @param {number} maxDepth - Maximum depth in meters
+ * @returns {Promise<number>} Count of depth levels within range
+ */
+export async function queryPiscesDepthCount(
+  searchDatabaseApi,
+  minDepth,
+  maxDepth,
+) {
+  try {
+    log.debug('querying pisces depth count', { minDepth, maxDepth });
+
+    const sql =
+      'SELECT COUNT(*) as count FROM pisces_depth WHERE depth_level BETWEEN ? AND ?';
+    const bindings = [minDepth, maxDepth];
+
+    const results = await searchDatabaseApi.executeSql(sql, bindings);
+
+    const count = results[0].count;
+    log.debug('pisces depth count', { minDepth, maxDepth, count });
+
+    return count;
+  } catch (error) {
+    log.error('error querying pisces depth count', {
+      minDepth,
+      maxDepth,
+      error: error.message,
+    });
+    return 0;
+  }
+}

--- a/src/shared/filtering/utils/dateHelpers.js
+++ b/src/shared/filtering/utils/dateHelpers.js
@@ -26,6 +26,24 @@ export const dateToDateString = (date) => {
   return formatDateString(fullYear, month, day);
 };
 
+// Convert Date to ISO date string with end-of-day time for max bounds
+// This ensures that when we filter with "date <= maxDate", we include
+// all data from that entire day, not just midnight
+export const dateToEndOfDayString = (date) => {
+  let value = new Date(date);
+
+  let month = value.getMonth() + 1;
+  month = month > 9 ? month : '0' + month;
+
+  let day = value.getDate();
+  day = day > 9 ? day : '0' + day;
+
+  let fullYear = value.getFullYear();
+
+  // Return date with time set to 23:59:59
+  return `${fullYear}-${month}-${day}T23:59:59`;
+};
+
 export const extractDateFromString = (stringDate) => {
   let [year, month, day] = stringDate.split('-');
   const date = new Date(year, parseInt(month) - 1, day);
@@ -85,20 +103,20 @@ export const getInitialRangeValues = (dataset) => {
 
   let initialValues = {
     lat: {
-      start: formatLatitude(Lat_Min),
-      end: formatLatitude(Lat_Max),
+      start: Lat_Min,
+      end: Lat_Max,
     },
     lon: {
-      start: formatLongitude(Lon_Min),
-      end: formatLongitude(Lon_Max),
+      start: Lon_Min,
+      end: Lon_Max,
     },
     time: {
       start: Time_Min ? new Date(Time_Min) : new Date(),
       end: Time_Max ? new Date(Time_Max) : new Date(),
     },
     depth: {
-      start: Math.floor(Depth_Min),
-      end: Math.ceil(Depth_Max),
+      start: Depth_Min,
+      end: Depth_Max,
     },
   };
 

--- a/src/shared/filtering/utils/filterTransformUtils.js
+++ b/src/shared/filtering/utils/filterTransformUtils.js
@@ -1,17 +1,32 @@
-import { dateToDateString } from './dateHelpers';
+import { dateToDateString, dateToEndOfDayString } from './dateHelpers';
+
+// Small epsilon for floating-point comparison tolerance
+// Ensures we capture boundary values that may have floating-point precision differences
+// Value of 0.000001 (~11cm for lat/lon, 1 micrometer for depth) is well below
+// oceanographic measurement precision while handling binary floating-point errors
+const SPATIAL_EPSILON = 0.000001;
+
+// Expand spatial bounds by epsilon to account for floating-point precision
+// For example: 32.108 in metadata might be 32.10800000000004 in actual data
+const expandSpatialBounds = (min, max) => ({
+  min: min - SPATIAL_EPSILON,
+  max: max + SPATIAL_EPSILON,
+});
 
 export const transformFiltersForAPI = (filters) => {
   const apiFilters = {};
 
   // Transform temporal filters - convert Date objects to date strings
+  // Use dateToEndOfDayString for endDate to include the entire last day (T23:59:59)
   if (filters.Time_Min) {
     apiFilters.temporal = {
       startDate: dateToDateString(filters.timeStart),
-      endDate: dateToDateString(filters.timeEnd),
+      endDate: dateToEndOfDayString(filters.timeEnd),
     };
   }
 
   // Transform spatial filters - map to API format
+  // Expand bounds by epsilon to handle floating-point precision issues
   if (
     filters.latStart !== undefined ||
     filters.latEnd !== undefined ||
@@ -20,11 +35,14 @@ export const transformFiltersForAPI = (filters) => {
     filters.depthStart !== undefined ||
     filters.depthEnd !== undefined
   ) {
+    const latBounds = expandSpatialBounds(filters.latStart, filters.latEnd);
+    const lonBounds = expandSpatialBounds(filters.lonStart, filters.lonEnd);
+
     apiFilters.spatial = {
-      latMin: filters.latStart,
-      latMax: filters.latEnd,
-      lonMin: filters.lonStart,
-      lonMax: filters.lonEnd,
+      latMin: latBounds.min,
+      latMax: latBounds.max,
+      lonMin: lonBounds.min,
+      lonMax: lonBounds.max,
     };
   }
 
@@ -33,8 +51,12 @@ export const transformFiltersForAPI = (filters) => {
     if (!apiFilters.spatial) {
       apiFilters.spatial = {};
     }
-    apiFilters.spatial.depthMin = filters.depthStart;
-    apiFilters.spatial.depthMax = filters.depthEnd;
+    const depthBounds = expandSpatialBounds(
+      filters.depthStart,
+      filters.depthEnd,
+    );
+    apiFilters.spatial.depthMin = depthBounds.min;
+    apiFilters.spatial.depthMax = depthBounds.max;
   }
 
   return apiFilters;

--- a/src/shared/pagination/usePagination.js
+++ b/src/shared/pagination/usePagination.js
@@ -48,10 +48,10 @@ const usePagination = ({ data, itemsPerPage = 10 }) => {
     return Math.ceil(data.length / validItemsPerPage);
   }, [data, validItemsPerPage]);
 
-  // Auto-reset to page 1 when data changes
+  // Auto-reset to page 1 when data length changes
   useEffect(() => {
     setCurrentPage(1);
-  }, [data]);
+  }, [data.length]);
 
   // Smart page correction when current page exceeds available pages
   useEffect(() => {


### PR DESCRIPTION
## Summary

  Adds frontend row count estimation for datasets in the Spatial-Temporal search tab,
  providing immediate feedback to users while more accurate backend calculations proceed. Also
   adds support for monthly climatology temporal resolution.

  ## Changes

  - Add row count estimation module with spatial/temporal/depth dimension calculations
  (`src/shared/estimation/`)
  - Implement streaming updates showing estimated counts immediately before backend
  recalculation completes
  - Add monthly climatology support in temporal resolution mappings and query templates
  - Create `rowCountCalculationStore` for managing calculation state, staleness detection, and
   constraint snapshots
  - Add per-dataset staleness indicators with tooltips explaining why counts may be inaccurate
  - Implement eligibility function to determine which datasets support frontend estimation
  - Add `CreateCollectionWithDatasetsModal` for creating collections directly from search
  results
  - Refactor column definitions and renderers into separate utility modules
  - Add constraint comparison utilities for deep equality checks with Date handling